### PR TITLE
(PPS-307): force dependencies to use newer versions of ansi-regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33439,7 +33439,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "3.0.1"
+            "ansi-regex": "^3.0.1"
           }
         }
       }
@@ -35079,7 +35079,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -35258,7 +35258,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -35425,7 +35425,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -35582,7 +35582,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -35634,7 +35634,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           }
@@ -35723,7 +35723,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -35816,7 +35816,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -36214,7 +36214,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -36378,7 +36378,7 @@
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           },
@@ -39886,7 +39886,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^26.6.2",
-        "ansi-regex": "5.0.1",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^4.0.0",
         "react-is": "^17.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   },
   "overrides": {
     "gauge": {
-      "ansi-regex": "3.0.1",
+      "ansi-regex": "^3.0.1",
       "strip-ansi": {
-        "ansi-regex": "3.0.1"
+        "ansi-regex": "^3.0.1"
       }
     },
     "pretty-format": {
-      "ansi-regex": "5.0.1"
+      "ansi-regex": "^5.0.1"
     }
   }
 }


### PR DESCRIPTION
Jira Ticket: [PPS-307](https://ctds-planx.atlassian.net/browse/PPS-307)
### Dependency updates
- add overrides for ansi-regex

[PPS-307]: https://ctds-planx.atlassian.net/browse/PPS-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ