### PR TITLE
Update email for email transition

### DIFF
--- a/packages/portal/config/aboutHEAL.json
+++ b/packages/portal/config/aboutHEAL.json
@@ -43,7 +43,7 @@
             "title": "HELP",
             "content": [
                 "Documentation",
-                "For more help, contact us at heal-support@datacommons.io"
+                "For more help, contact us at heal-support@gen3.org"
             ]
         }
     ]

--- a/packages/portal/src/pages/landing/contact.tsx
+++ b/packages/portal/src/pages/landing/contact.tsx
@@ -18,8 +18,8 @@ const ContactPage = ( {footerProps, headerProps}: NavPageLayoutProps) => {
           <h1 className='font-bold text-4xl text-gen3-coal font-montserrat pb-4'>Contact</h1>
           <Text className='prose text-black text-2xl p-8'>
                     For technical questions about the HEAL Platform, contact our Platform Team from CTDS-Gen3 at
-            <a className='text-gen3-base_blue flex flex-row items-baseline no-underline font-bold' href='mailto:heal-support@datacommons.io'>
-              <FaEnvelope className='pr-1 pt-2'/> heal-support@datacommons.io
+            <a className='text-gen3-base_blue flex flex-row items-baseline no-underline font-bold' href='mailto:heal-support@gen3.org'>
+              <FaEnvelope className='pr-1 pt-2'/> heal-support@gen3.org
             </a>
           </Text>
           <Text className='prose text-black text-2xl p-8'>


### PR DESCRIPTION
update email from heal-support@datacommons.io to heal-support@gen3.org

Do not merge until gen3.org emails are active