### PR TITLE
PROM-111: add charts to discovery page

### DIFF
--- a/packages/frontend/src/components/Providers/Gen3Provider.tsx
+++ b/packages/frontend/src/components/Providers/Gen3Provider.tsx
@@ -67,6 +67,15 @@ const createMantineTheme = (
       lg: '80em',
       xl: '112.5em',
     },
+    components: {
+      Modal: {
+        defaultProps: {
+          classNames: {
+            title: 'font-bold',
+          },
+        },
+      },
+    },
   });
 
   return theme;

--- a/packages/frontend/src/components/charts/Charts.tsx
+++ b/packages/frontend/src/components/charts/Charts.tsx
@@ -1,7 +1,10 @@
-import { fieldNameToTitle, AggregationsData } from '@gen3/core';
+import React from 'react';
+import { fieldNameToTitle, AggregationsData, HistogramDataArray } from '@gen3/core';
 //import { MdClose as CloseIcon } from 'react-icons/md';
+import { Icon } from '@iconify/react';
 //import { useDeepCompareMemo } from 'use-deep-compare';
 
+import { useDisclosure } from '@mantine/hooks';
 import {
   // ActionIcon,
   Card,
@@ -9,13 +12,20 @@ import {
   Group,
   Text,
   LoadingOverlay,
+  Table,
+  ColorSwatch,
+  Modal,
+  Button,
+  useMantineTheme,
 } from '@mantine/core';
+
 import { createChart } from './createChart';
 import { SummaryChart } from './types';
 
 import { computeRowSpan } from './utils';
 
 const DEFAULT_COLS = 3;
+const MAX_LEGEND_ROWS = 4;
 
 export type ChartDataConverter = (
   data: Record<string, number>,
@@ -29,7 +39,21 @@ interface ChartsProps {
   isSuccess: boolean;
   isError?: boolean;
   numCols?: number;
+  style?: 'tile' | 'box';
+  showLegends?: boolean;
 }
+//Colors grabbed from echarts src/model/globalDefault.ts
+const chartColors = [
+  '#5470c6',
+  '#91cc75',
+  '#fac858',
+  '#ee6666',
+  '#73c0de',
+  '#3ba272',
+  '#fc8452',
+  '#9a60b4',
+  '#ea7ccc'
+];
 
 //The Charts component maps the data from ChartsProps into a grid of createChart() ReactNodes
 const Charts = ({
@@ -39,36 +63,127 @@ const Charts = ({
   counts,
   isSuccess,
   numCols = DEFAULT_COLS,
+  style = 'tile',
+  showLegends = false,
 }: ChartsProps) => {
   const spans = computeRowSpan(charts, numCols);
+  
+  const chartCard = (field: string, indexNum: number) => {
 
+    const LegendRows = ({ data }: { data:  HistogramDataArray }) => {
+      const moreThanMaxRows = data.length > MAX_LEGEND_ROWS;
+      const limitedRows = moreThanMaxRows ? data.slice(0,MAX_LEGEND_ROWS) : data;
+
+      return limitedRows.map((element, elIndex) => (
+        <Table.Tr key={elIndex}>
+          <Table.Td><ColorSwatch className="inline-block mr-2 align-middle" size="1em" radius="xs" color={chartColors?.[elIndex % chartColors.length] || ''}/>{element.key}</Table.Td>
+          <Table.Td className="text-right">{element.count}</Table.Td>
+        </Table.Tr>
+      ));
+    };
+
+    const LegendOverflow = ({ chart, data, chartTitle }: { chart: SummaryChart, data:  HistogramDataArray, chartTitle: string }) => {
+      const [openedMoreRows, { open: openMoreRows, close: closeMoreRows }] = useDisclosure(false);
+      const theme = useMantineTheme();
+      return (
+        <React.Fragment>
+          <Modal opened={openedMoreRows} onClose={closeMoreRows} title={chartTitle} size="xl">
+            <Grid>
+              <Grid.Col span={6} key="modal-col-1">
+                  {createChart(chart.chartType, {
+                    data: data === undefined ? [] : data,
+                    total: counts ?? 1,
+                    valueType: chart.valueType ?? 'count',
+                  })}
+              </Grid.Col>
+              <Grid.Col span={6} key="modal-col-2">
+                <div className="border-solid border-[1px] border-[var(--mantine-color-gray-3)] h-full p-1">
+                  <Table 
+                    withRowBorders={false} 
+                    classNames={{
+                      table: '',
+                      td: 'p-1 leading-3',
+                    }}>
+                    <Table.Tbody>
+                      {data.map((element, elIndex) => (
+                        <Table.Tr key={elIndex}>
+                          <Table.Td><ColorSwatch className="inline-block mr-2 align-middle" size="1em" radius="xs" color={chartColors?.[elIndex % chartColors.length] || ''}/>{element.key}</Table.Td>
+                          <Table.Td className="text-right">{element.count}</Table.Td>
+                        </Table.Tr>
+                      ))}
+                    </Table.Tbody>
+                  </Table>
+                </div>
+              </Grid.Col>
+            </Grid>
+          </Modal>
+          <Button variant="subtle" onClick={openMoreRows} leftSection={<Icon icon="gen3:open-in-modal" height={24} width={24} color={theme.colors.accent[5]}/>} className="text-black hover:text-black">{data.length - MAX_LEGEND_ROWS} more</Button>
+        </React.Fragment>
+      );
+    };
+
+    const dataKeys = Object.keys(data[field][0]);
+
+    const chartTitle = charts[field].title ?? fieldNameToTitle(field);
+
+    const moreThanMaxRows = data?.[field] && data[field].length > MAX_LEGEND_ROWS;
+
+    return (<Grid.Col span={spans[indexNum]} key={`${index}-${indexNum}-charts-${field}-col`}>
+      <Card shadow="md" withBorder={style === 'box'} className="h-full">
+        <Card.Section inheritPadding py="xs" withBorder={style === 'box'}>
+          <Group justify="space-between">
+            <Text fw={900} className={`${style === 'box'?'font-bold [text-shadow:_1px_0_#000]':''}`}>
+              {chartTitle}
+            </Text>
+            {/* // TODO: handle close/hide chart
+            <ActionIcon>
+              <CloseIcon size="1rem" />
+            </ActionIcon>
+             */}
+          </Group>
+        </Card.Section>
+        <LoadingOverlay visible={!isSuccess} />
+        {createChart(charts[field].chartType, {
+          data: data === undefined ? [] : data[field],
+          total: counts ?? 1,
+          valueType: charts[field].valueType ?? 'count',
+        })}
+        {showLegends && (
+        <Card.Section inheritPadding py="xs" withBorder={style === 'box'}>
+          <Table 
+            withRowBorders={false} 
+            classNames={{
+              td: 'p-1 leading-3',
+              th: 'p-1 leading-3 [text-shadow:_1px_0_#000]',
+              thead: 'border-b',
+              tbody: 'before:content-[\'\'] before:block before:p-1',
+            }}>
+            <Table.Thead>
+              <Table.Tr>
+                {
+                  dataKeys.map((el, i)=>(
+                    <Table.Th className="last:text-right" key={i}>{charts[field]?.dataLabels?.[el] || <React.Fragment>&nbsp;</React.Fragment>}</Table.Th>
+                  ))
+                }
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {data === undefined ? '' : <LegendRows data={data[field]}/>}
+            </Table.Tbody>
+          </Table>
+        </Card.Section>)}
+        {showLegends && moreThanMaxRows && (
+        <Card.Section inheritPadding withBorder={style === 'box'} className="text-right p-1">
+          <LegendOverflow chart={charts[field]} data={data[field]} chartTitle={chartTitle}/>
+        </Card.Section>)}
+      </Card>
+    </Grid.Col>);
+  };
+  
   return (
-    <Grid className="w-full mx-2">
+    <Grid className="w-full">
       {data &&
-        Object.keys(charts).map((field, index) => (
-          <Grid.Col span={spans[index]} key={`${index}-charts-${field}-col`}>
-            <Card shadow={'md'}>
-              <Card.Section inheritPadding py="xs">
-                <Group justify="space-between">
-                  <Text fw={900}>
-                    {charts[field].title ?? fieldNameToTitle(field)}
-                  </Text>
-                  {/* // TODO: handle close/hide chart
-                  <ActionIcon>
-                    <CloseIcon size="1rem" />
-                  </ActionIcon>
-                   */}
-                </Group>
-              </Card.Section>
-              <LoadingOverlay visible={!isSuccess} />
-              {createChart(charts[field].chartType, {
-                data: data === undefined ? [] : data[field],
-                total: counts ?? 1,
-                valueType: charts[field].valueType ?? 'count',
-              })}
-            </Card>
-          </Grid.Col>
-        ))}
+        Object.keys(charts).map(chartCard)}
     </Grid>
   );
 };

--- a/packages/frontend/src/components/charts/tests/utils.unit.test.ts
+++ b/packages/frontend/src/components/charts/tests/utils.unit.test.ts
@@ -35,8 +35,8 @@ describe('computeRowSpan', () => {
   it('computes the correct row span', () => {
     const charts: Record<string, SummaryChart> = {
       chart1: { title: 'Chart 1', chartType: 'bar' },
-      chart2: { title: 'Chart 2', chartType: 'line', valueType: 'count' },
-      chart3: { title: 'Chart 3', chartType: 'pie', valueType: 'percent' },
+      chart2: { title: 'Chart 2', chartType: 'horizontalStacked', valueType: 'count' },
+      chart3: { title: 'Chart 3', chartType: 'fullPie', valueType: 'percent' },
     };
 
     const numCols = 2;
@@ -49,7 +49,7 @@ describe('computeRowSpan', () => {
   it('handles edge case where number of charts is divisible by number of columns', () => {
     const charts: Record<string, SummaryChart> = {
       chart1: { title: 'Chart 1', chartType: 'bar' },
-      chart2: { title: 'Chart 2', chartType: 'line', valueType: 'count' },
+      chart2: { title: 'Chart 2', chartType: 'horizontalStacked', valueType: 'count' },
     };
 
     const numCols = 2;

--- a/packages/frontend/src/components/charts/types.ts
+++ b/packages/frontend/src/components/charts/types.ts
@@ -2,8 +2,9 @@ import { HistogramDataArray } from '@gen3/core';
 
 export interface SummaryChart {
   readonly title: string;
-  readonly chartType: string;
+  readonly chartType: 'bar' | 'horizontalStacked' | 'fullPie' | 'donut';
   readonly valueType?: 'count' | 'percent';
+  readonly dataLabels?: Record<string, string>;
 }
 
 export interface ChartProps {

--- a/packages/frontend/src/features/Discovery/Charts/ChartsPanel.tsx
+++ b/packages/frontend/src/features/Discovery/Charts/ChartsPanel.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import { ChartsSection } from '../types';
+import { Accordion, Switch, Divider, Box } from '@mantine/core';
+import { Charts } from '../../../components/charts';
+import { SummaryChart } from '../../../components/charts/types';
+
+
+
+const ChartsPanel = ({ config }: {config: ChartsSection}) => {
+  const [showLegends, setShowLegends] = useState(config.showLegends?.enabled);
+  if (!(config?.charts && config.charts.length > 0)) {
+    console.error('Discovery Charts Section not setup properly');
+    return;
+  }
+  const chartsProperties = () => {
+    const chartDataTemp: Record<string, SummaryChart> = {};
+    config?.charts?.forEach((chart, index)=>{
+      chartDataTemp[`testName${index}`] = {//TODO use from data
+        title: chart.title,
+        chartType: chart.chartType,
+        valueType: chart.valueType,
+        dataLabels: chart.dataLabels //TODO get from code and not from setup
+      };
+    });
+    return chartDataTemp;
+  };
+  return (
+    <Accordion unstyled classNames={{
+      root: 'mb-4 bg-base-max w-full rounded-lg',
+      control: 'bg-secondary-lightest w-full px-4 py-2 rounded-lg data-active:rounded-b-none text-left group',
+      label: 'pl-2 font-bold [text-shadow:_1px_0_#000]',
+      chevron: 'rounded-full bg-secondary-dark text-white inline-block align-middle group-data-[active]:rotate-180 transition-all',
+      panel: 'py-4'
+    }}
+    chevronPosition="left"
+    defaultValue="chartsAccordion">
+      <Accordion.Item value={'chartsAccordion'}>
+      <Accordion.Control>{config.title || ''}</Accordion.Control>
+        <Accordion.Panel>
+          {config.showLegends?.enabled && config.showLegends?.showSwitch && (
+            <React.Fragment>
+              <Switch
+                color="accent"
+                labelPosition="left"
+                label="Show legends"
+                size="xs"
+                px="md"
+                checked={showLegends}
+                onChange={(event) => setShowLegends(event.currentTarget.checked)}
+              />
+              <Divider my="sm"/>
+            </React.Fragment>
+          )}
+          <Box px="md">
+            <Charts
+              showLegends={showLegends}
+              style="box"
+              index={'subjectsCharts'}
+              charts={chartsProperties()}
+              data={{
+                'testName0':[{
+                  key: 'a',
+                  count: 11
+                },
+                {
+                  key: 'b',
+                  count: 9
+                },
+                {
+                  key: 'c',
+                  count: 3
+                },
+                {
+                  key: 'd',
+                  count: 1
+                },
+                {
+                  key: 'e',
+                  count: 0
+                }],
+                'testName1':[{
+                  key: 'a',
+                  count: 11
+                },
+                {
+                  key: 'b',
+                  count: 9
+                },
+                {
+                  key: 'c',
+                  count: 3
+                }],
+                'testName2':[{
+                  key: 'a',
+                  count: 11
+                },
+                {
+                  key: 'b',
+                  count: 9
+                },
+                {
+                  key: 'c',
+                  count: 3
+                }],
+                'testName3':[{
+                  key: 'a',
+                  count: 1
+                },
+                {
+                  key: 'b',
+                  count: 2
+                },
+                {
+                  key: 'c',
+                  count: 3
+                },
+                {
+                  key: 'd',
+                  count: 4
+                },
+                {
+                  key: 'e',
+                  count: 5
+                },
+                {
+                  key: 'f',
+                  count: 6
+                },
+                {
+                  key: 'g',
+                  count: 7
+                },
+                {
+                  key: 'h',
+                  count: 8
+                },
+                {
+                  key: 'i',
+                  count: 9
+                },
+                {
+                  key: 'j',
+                  count: 10
+                },
+                {
+                  key: 'k',
+                  count: 11
+                }]
+              }}
+              counts={2}
+              isSuccess={true}
+              numCols={4}
+            />
+          </Box>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  );
+};
+
+export default ChartsPanel;

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -2,13 +2,13 @@ import React, { useMemo, useRef, useState, ReactNode } from 'react';
 import { DiscoveryIndexConfig } from './types';
 import DiscoveryTable from './DiscoveryTable';
 import DiscoveryProvider from './DiscoveryProvider';
-import { Loader, Text } from '@mantine/core';
+import { Loader, Text, Button } from '@mantine/core';
 import AdvancedSearchPanel from './Search/AdvancedSearchPanel';
 import { MRT_PaginationState, MRT_SortingState } from 'mantine-react-table';
 import { useDisclosure } from '@mantine/hooks';
-import { Button } from '@mantine/core';
 import ActionBar from './ActionBar/ActionBar';
 import SummaryStatisticPanel from './Statistics/SummaryStatisticPanel';
+import ChartsPanel from './Charts/ChartsPanel';
 import { useLoadAllMDSData } from './DataLoaders/MDSAllLocal/DataLoader';
 import { AdvancedSearchTerms, SearchCombination } from './Search/types';
 import SearchInputWithSuggestions from './Search/SearchInputWithSuggestions';
@@ -100,6 +100,9 @@ const DiscoveryIndexPanel = ({
           discoveryConfig?.features?.pageTitle.enabled ? (
             <Text size="xl">{discoveryConfig?.features?.pageTitle.text}</Text>
           ) : null}
+          {discoveryConfig.features?.chartsSection?.enabled && (
+            <ChartsPanel config={discoveryConfig.features?.chartsSection}/>
+          )}
           <div className="flex items-center p-2 mb-4 bg-base-max rounded-lg">
             {indexSelector}
             <SummaryStatisticPanel summaries={summaryStatistics} />

--- a/packages/frontend/src/features/Discovery/types.ts
+++ b/packages/frontend/src/features/Discovery/types.ts
@@ -6,6 +6,7 @@ import {
 import DataLibraryActionButton from './ActionBar/DataLibraryActionButton';
 import { SummaryStatistics, SummaryStatisticsConfig } from './Statistics/types';
 import { AdvancedSearchTerms, SearchCombination } from './Search/types';
+import { SummaryChart } from '../../components/charts/types';
 
 export interface TagData {
   name: string;
@@ -268,6 +269,17 @@ export interface TagsConfig {
   tagCategories: TagCategory[];
   showUnknownTags?: boolean;
 }
+export interface ChartsSection {
+  enabled: boolean;
+  title?: string;
+  showLegends?: {
+    enabled: boolean;
+    showSwitch?: boolean;
+  };
+  charts?: Array<SummaryChart & {
+      data: string[];
+    }>;
+}
 
 // TODO: Type the rest of the config
 export interface DiscoveryIndexConfig {
@@ -282,6 +294,7 @@ export interface DiscoveryIndexConfig {
     search?: SearchConfig;
     authorization: DataAuthorization;
     dataLoader?: DataLoader;
+    chartsSection?: ChartsSection;
   };
   aggregations: SummaryStatisticsConfig[];
   tags: TagsConfig;


### PR DESCRIPTION

Link to JIRA ticket if there is one: [PROM-111](https://ctds-planx.atlassian.net/browse/PROM-111)

### New Features
- add charts to discovery page
- uses mock data as data endpoint still needs to be hooked up 