### PR TITLE
Fix fetch to return presigned url, not object

### DIFF
--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -114,7 +114,7 @@ export const fetchFencePresignedURL = async ({
       throw new HTTPError(response.status, errorMessage, errorData);
     }
 
-    return await response.json();
+    return (await response.json())['url'];
   } catch (error: unknown) {
     if (error instanceof Error) {
       if (error.name === 'AbortError') {


### PR DESCRIPTION

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- presigned url fetch now returns the presigned url rather than the object response from fence.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
