### PR TITLE
feat: Add external login configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,5 @@ packages/sampleCommons/config/canine
 packages/sampleCommons/config/midrc
 packages/sampleCommons/config/heal
 packages/sampleCommons/config/bdc
-packages/sampleCommons/.env.development
 /packages/frontend/.rollup.cache/
 /packages/sampleCommons/.swc/

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ yarn-error.log*
 packages/sampleCommons/config/canine
 packages/sampleCommons/config/midrc
 packages/sampleCommons/config/heal
+packages/sampleCommons/config/bdc
+packages/sampleCommons/.env.development
 /packages/frontend/.rollup.cache/
 /packages/sampleCommons/.swc/

--- a/packages/frontend/src/components/Login/LoginButton.tsx
+++ b/packages/frontend/src/components/Login/LoginButton.tsx
@@ -19,8 +19,9 @@ const handleSelected = async (
   router: NextRouter,
   referrer: string,
   endSession?: () => void,
+  externalLoginUrl?: string,
 ) => {
-  if (!isAuthenticated) await router.push(`Login?redirect=${referrer}`);
+  if (!isAuthenticated) await router.push(externalLoginUrl || `Login?redirect=${referrer}`);
   else {
     if (endSession) endSession();
   }
@@ -32,6 +33,7 @@ interface LoginButtonProps {
   className?: string;
   tooltip?: string;
   visibility: LoginButtonVisibility;
+  externalLoginUrl?: string;
 }
 
 const LoginButton = ({
@@ -40,6 +42,7 @@ const LoginButton = ({
   className = undefined,
   tooltip,
   visibility,
+  externalLoginUrl,
 }: LoginButtonProps) => {
   const router = useRouter();
 
@@ -74,7 +77,7 @@ const LoginButton = ({
     >
       <UnstyledButton
         onClick={() =>
-          handleSelected(authenticated, router, pathname, endSession)
+          handleSelected(authenticated, router, pathname, endSession, externalLoginUrl)
         }
       >
         <div className={mergedClassname}>

--- a/packages/frontend/src/components/Modals/Gen3ModalsProvider.tsx
+++ b/packages/frontend/src/components/Modals/Gen3ModalsProvider.tsx
@@ -36,7 +36,7 @@ const getModal = (
       break;
     }
     case Modals.SessionExpireModal: {
-      res = <SessionExpiredModal openModal={true} />;
+      res = <SessionExpiredModal openModal={true} config={config.sessionExpiredModal}/>;
       break;
     }
   }

--- a/packages/frontend/src/components/Modals/SessionExpiredModal.tsx
+++ b/packages/frontend/src/components/Modals/SessionExpiredModal.tsx
@@ -2,16 +2,20 @@ import { useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { Text } from '@mantine/core';
 import { BaseModal } from './BaseModal';
+import { SessionExpiredModalConfig } from "./types";
 
+interface SessionExpiredModalProps {
+  readonly openModal: boolean;
+  config: SessionExpiredModalConfig | undefined;
+}
 export const SessionExpiredModal = ({
   openModal,
-}: {
-  openModal: boolean;
-}): JSX.Element => {
+  config
+}: SessionExpiredModalProps): JSX.Element => {
 
   const router = useRouter();
   const onLogout = useCallback(() => {
-    router.push('/Login');
+    router.push(config?.externalLoginUrl || '/Login');
   }, [router]);
 
   return (

--- a/packages/frontend/src/components/Modals/types.ts
+++ b/packages/frontend/src/components/Modals/types.ts
@@ -12,7 +12,11 @@ export interface FirstTimeModalConfig extends BaseModalConfig{
   expireDays?: number;
 }
 
+export interface SessionExpiredModalConfig extends BaseModalConfig{
+  externalLoginUrl?: string;
+}
 
 export interface ModalsConfig {
   systemUseModal?: FirstTimeModalConfig;
+  sessionExpiredModal?: SessionExpiredModalConfig;
 }

--- a/packages/frontend/src/features/Navigation/Header.tsx
+++ b/packages/frontend/src/features/Navigation/Header.tsx
@@ -46,6 +46,7 @@ const Header = ({
       <TopBar
         items={top.items}
         loginButtonVisibility={top?.loginButtonVisibility}
+        externalLoginUrl={top?.externalLoginUrl}
         classNames={{ ...top.classNames }}
       />
       {banners?.map((banner) => <Banner {...banner} key={banner.id} />)}

--- a/packages/frontend/src/features/Navigation/TopBar.tsx
+++ b/packages/frontend/src/features/Navigation/TopBar.tsx
@@ -102,12 +102,14 @@ const processTopBarItems = (
 export interface TopBarProps {
   readonly items: TopIconButtonProps[];
   readonly loginButtonVisibility?: LoginButtonVisibility;
+  readonly externalLoginUrl?: string;
   readonly classNames?: StylingOverrideWithMergeControl;
 }
 
 const TopBar = ({
   items,
   loginButtonVisibility = LoginButtonVisibility.Hidden,
+  externalLoginUrl,
   classNames = {},
 }: TopBarProps) => {
   const classNamesDefaults = {
@@ -144,6 +146,7 @@ const TopBar = ({
             <div className="flex items-center">
               <LoginButton
                 visibility={loginButtonVisibility}
+                externalLoginUrl={externalLoginUrl}
                 className={extractClassName('login', mergedClassnames)}
               />
             </div>

--- a/packages/sampleCommons/.env.development
+++ b/packages/sampleCommons/.env.development
@@ -1,5 +1,5 @@
-GEN3_COMMONS_NAME=bdc
-NEXT_PUBLIC_GEN3_API=https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/
+GEN3_COMMONS_NAME=gen3
+NEXT_PUBLIC_GEN3_API=https://localhost:3010
 
 ## For more fine grain control over the API uncomment the relevant lines
 #NEXT_PUBLIC_GEN3_SUBMISSION_API=https://localhost:3010/api/v0/submission

--- a/packages/sampleCommons/.env.development
+++ b/packages/sampleCommons/.env.development
@@ -1,5 +1,5 @@
-GEN3_COMMONS_NAME=gen3
-NEXT_PUBLIC_GEN3_API=https://localhost:3010
+GEN3_COMMONS_NAME=bdc
+NEXT_PUBLIC_GEN3_API=https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/
 
 ## For more fine grain control over the API uncomment the relevant lines
 #NEXT_PUBLIC_GEN3_SUBMISSION_API=https://localhost:3010/api/v0/submission


### PR DESCRIPTION
Adds configuration for URL to forward users to for login. This is useful for commons where the login page is separate from the FEF, such as in data-portal hybrids.

Link to JIRA ticket if there is one: 

### New Features
- Adds support to allow users to login from external sources. 
### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
