### PR TITLE
render the email address instead of raw oidc id

### DIFF
--- a/packages/frontend/src/components/Login/LoginAccountButton.tsx
+++ b/packages/frontend/src/components/Login/LoginAccountButton.tsx
@@ -36,9 +36,13 @@ const LoginAccountButton = ({
   );
 
   if (userStatus && isAuthenticated(userStatus)) {
+    const displayName =
+    userInfo?.email ||
+    userInfo?.preferred_username ||
+    userInfo?.username;
     return (
       <UnstyledButton className="mx-2" onClick={() => handleSelected()}>
-        <div className={mergedClassname}>{userInfo?.username}</div>
+        <div className={mergedClassname}>{displayName}</div>
       </UnstyledButton>
     );
   }

--- a/packages/frontend/src/components/Profile/User.tsx
+++ b/packages/frontend/src/components/Profile/User.tsx
@@ -4,7 +4,10 @@ import { Avatar, Card, Group, LoadingOverlay, Text } from '@mantine/core';
 
 const User = () => {
   const { data: userData, isFetching } = useUserAuth();
-
+  const displayName =
+  userData?.email ||
+  userData?.preferred_username ||
+  userData?.username;
   return (
     <div className="w-full h-full">
       <LoadingOverlay visible={isFetching} />
@@ -12,7 +15,7 @@ const User = () => {
         <Card shadow="sm" radius="md" withBorder>
           <Group justify="space-between" mt="md" mb="xs">
             <Avatar radius="xl" color="accent.6"></Avatar>
-            <Text fw={500}>{userData?.username}</Text>
+            <Text fw={500}>{displayName}</Text>
           </Group>
         </Card>
       </div>

--- a/packages/frontend/src/features/Navigation/TopBar/AccountButton.tsx
+++ b/packages/frontend/src/features/Navigation/TopBar/AccountButton.tsx
@@ -52,10 +52,14 @@ export const AccountButton = ({
 
   // get the icon size otherwise use the value of iconsSize as a string value: e.g. 2em
   const iconSz = IconSize[iconSize] ?? iconSize;
+  const displayName =
+  userInfo?.email ||
+  userInfo?.preferred_username ||
+  userInfo?.username;
 
   return (
     <IconButton
-      name={userInfo?.username ?? 'Profile'}
+      name={displayName ?? 'Profile'}
       leftIcon={leftIcon}
       rightIcon={rightIcon}
       iconSize={iconSize}


### PR DESCRIPTION

<!--
Improvements

Currently the Frontend-Framework header and profile popover display the raw OIDC username claim (e.g. auth0|6859fbba9cdla5dbea2fdbe4). This is confusing for users. Fence already returns the user’s email in /user. We should render the email address instead, falling back to other available claims.

Before:
<img width="844" height="270" alt="image" src="https://github.com/user-attachments/assets/d68ec2a8-82ec-4539-a931-135337d60092" />

After:
<img width="422" height="135" alt="Screenshot 2025-10-10 at 11 31 02 AM" src="https://github.com/user-attachments/assets/dc3c0460-f633-4538-bbdc-11eb7fc2dced" />


### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
