### PR TITLE
open documentation link in new window

### DIFF
--- a/docs/Configuration/Navigation.md
+++ b/docs/Configuration/Navigation.md
@@ -55,14 +55,21 @@ Similar to the navigation items, each top bar item has the following properties:
 - **rightIcon** (optional): An icon displayed to the right of the item text.
 - **href**: The URL to which the item links.
 - **name**: The text displayed for the item.
+- **newWindow**: Whether the link should be opened in a new window/tab.
 
-Example of a top bar item:
+Example of top bar items:
 
 ```json
 {
   "rightIcon": "gen3:upload",
   "href": "/submission",
   "name": "Browse Data"
+}
+
+{
+  "href": "http://example.com/documentation",
+  "name": "Example Documentation",
+  "newWindow": true
 }
 ```
 

--- a/packages/frontend/src/features/Navigation/ActionMenu.tsx
+++ b/packages/frontend/src/features/Navigation/ActionMenu.tsx
@@ -31,9 +31,18 @@ const ActionMenu = ({ items }: ActionMenuProps) => {
           {items.map((x, index) => {
             return (
               <Menu.Item key={`${x.name}-${index}`}>
-                <Link href={x.href}>
-                  <Text>{x.name}</Text>
-                </Link>
+                {x.newWindow === true ? (
+                  <Link
+                    href={x.href}
+                    target="_blank"
+                  >
+                    <Text>{x.name}</Text>
+                  </Link>
+                ) : (
+                  <Link href={x.href}>
+                    <Text>{x.name}</Text>
+                  </Link>
+                )}
               </Menu.Item>
             );
           })}

--- a/packages/frontend/src/features/Navigation/TopBar/IconButton.tsx
+++ b/packages/frontend/src/features/Navigation/TopBar/IconButton.tsx
@@ -16,6 +16,7 @@ export interface TopIconButtonProps extends NameAndIcon {
 
 export interface TopIconButtonPropsWithLink extends TopIconButtonProps {
   href: string;
+  newWindow?: bool;
 }
 
 export const IconButton = ({

--- a/packages/frontend/src/features/Navigation/TopBar/TopBar.tsx
+++ b/packages/frontend/src/features/Navigation/TopBar/TopBar.tsx
@@ -23,7 +23,7 @@ const processTopBarItems = (
       const Custom = item.component;
       acc.push(
         <React.Fragment key={`${item.href}_${item.name}-topbar-item`}>
-          <a className="flex" href={item.href}>
+          <a className="flex" href={item.href} target={item.newWindow === true ? "_blank" : null}>
             {Custom ? (
               Custom
             ) : (

--- a/packages/frontend/src/lib/common/staticProps.ts
+++ b/packages/frontend/src/lib/common/staticProps.ts
@@ -26,7 +26,7 @@ export const getNavPageLayoutPropsFromConfig =
             name: 'Site navigation is not configured',
             icon: '',
             tooltip: '',
-            href: '',
+            href: ''
           },
         ],
       },


### PR DESCRIPTION
if topBar item has newWindow set to true, use target=_blank to open link in new window/tab

Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/MC2DP-526

### New Features
Navigation Top Bar should now open links in new window if newWindow is set to true in config
