### PR TITLE
PXP-11433: exportActions checks selected items in Data Library

### DIFF
--- a/packages/frontend/src/features/DataLibrary/selection/exportActions.ts
+++ b/packages/frontend/src/features/DataLibrary/selection/exportActions.ts
@@ -39,9 +39,8 @@ export const sendExistingPFBToURL: DataActionFunction = async (
     return;
   }
   const { targetURLTemplate } = params;
-  // get the selection
-
-  if (validatedSelections.length !== 1 || !isFileItem(validatedSelections[0])) {
+  const selections = validatedSelections.filter((item) => item.valid)
+  if (selections.length !== 1 || !isFileItem(selections[0])) {
     notifications.show({
       id: 'data-library-send-existing-pfb-to-url-validate-length',
       position: 'bottom-center',
@@ -54,7 +53,7 @@ export const sendExistingPFBToURL: DataActionFunction = async (
     });
     return;
   }
-  const { guid, id } = validatedSelections[0] as FileItem;
+  const { guid, id } = selections[0] as FileItem;
 
   // get the pre-signed URL for the selected PFB
   try {

--- a/packages/sampleCommons/.env.development
+++ b/packages/sampleCommons/.env.development
@@ -1,5 +1,5 @@
-NEXT_PUBLIC_GEN3_COMMONS_NAME=gen3
-NEXT_PUBLIC_GEN3_API=https://localhost:3010
+NEXT_PUBLIC_GEN3_COMMONS_NAME=bdc
+NEXT_PUBLIC_GEN3_API=https://gen3.biodatacatalyst.nhlbi.nih.gov/
 NEXT_PUBLIC_GEN3_COHORT_DISCOVERY_LIMIT=1000
 
 ## For more fine grain control over the API uncomment the relevant lines


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/PXP-11433

### New Features

### Breaking Changes

### Bug Fixes
- exportActions now uses valid items in validatedSelections for sendExistingPFBToURL. This fixes an issue where all items in SelectedItemsModal were used, not just the selected and valid items, blocking PFB export if the SelectedItemsModal had more than one item.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
