### PR TITLE
v0.12.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "version": "0.11.62"
+  "version": "0.12.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49461,15 +49461,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.15.23",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vfile": {
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
@@ -51183,7 +51174,7 @@
     },
     "packages/core": {
       "name": "@gen3/core",
-      "version": "0.11.62",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.5.0",
@@ -51258,13 +51249,13 @@
     },
     "packages/frontend": {
       "name": "@gen3/frontend",
-      "version": "0.11.62",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
-        "@gen3/core": "^0.11.62",
+        "@gen3/core": "^0.12.0",
         "@graphiql/react": "^0.23.1",
         "@hello-pangea/dnd": "^17.0.0",
         "@iconify-icon/react": "^3.0.3",
@@ -51630,7 +51621,7 @@
     },
     "packages/sampleCommons": {
       "name": "@gen3/samplecommons",
-      "version": "0.11.62",
+      "version": "0.12.0",
       "dependencies": {
         "@fontsource/montserrat": "^5.0.19",
         "@fontsource/poppins": "^5.0.15",
@@ -52989,7 +52980,7 @@
     },
     "packages/storybook": {
       "name": "@gen3/storybook",
-      "version": "0.11.62",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "next": "^15.3.3"
@@ -53288,7 +53279,7 @@
     },
     "packages/tools": {
       "name": "@gen3/toolsff",
-      "version": "0.11.62",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@iconify/tools": "^4.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/core",
-  "version": "0.11.62",
+  "version": "0.12.0",
   "author": "CTDS",
   "description": "Core module for Gen3.2. Packages provides an interface for interacting with the gen3 API, various types, and a redux store for managing state.",
   "license": "Apache-2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/frontend",
-  "version": "0.11.62",
+  "version": "0.12.0",
   "description": "Gen3 frontend components, content management, and pages",
   "keywords": [],
   "author": "Center for Translational Data Science",
@@ -57,7 +57,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
-    "@gen3/core": "^0.11.62",
+    "@gen3/core": "^0.12.0",
     "@graphiql/react": "^0.23.1",
     "@hello-pangea/dnd": "^17.0.0",
     "@iconify-icon/react": "^3.0.3",

--- a/packages/sampleCommons/package.json
+++ b/packages/sampleCommons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/samplecommons",
-  "version": "0.11.62",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "lint": "next lint",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/storybook",
-  "version": "0.11.62",
+  "version": "0.12.0",
   "private": true,
   "description": "Storybook for testing and CI/CD",
   "keywords": [

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/toolsff",
-  "version": "0.11.62",
+  "version": "0.12.0",
   "description": "tools for processing Gen3 commons content: color theme, icons, sharedFilters",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MC2DP-505

### New Features
Adds authz support using NestJS Middleware.

# Setting up password and authentication for pages

Each page can be protected with a password and optionally enforce authorization. By default, all pages are unprotected
except Profile, Data Library, and Workspaces, which require the user be logged in.

When a page is protected, the user will be prompted for a password before being able to view the page or that navigation
link will not be displayed.

## Configuration

The password for each page can be set in the `config/gen3/authz,json` file. The default configuration is:
```json

{
  "enableAuthz": false,
  "routes": {
    "/DataLibrary": {
      "loginRequired": true
    },
    "/Workspace": {
      "loginRequired": true
    },
    "/Profile": {
      "loginRequired": true
    },
    "*": {
      "loginRequired": false
    }
  }
}
```
The `enableAuthz` flag enables or disables authorization for pages that require it. This flag is set to `false` by default.
It only controls whether the user is prompted for a password or not.

The `routes` object contains the mapping between the page path and the authentication and authorization settings for that page.
Each entry in the `routes` object is a key-value pair where the key is the page path and the value is an object containing the
authentication and authorization settings. If login is required for a page, the `loginRequired` flag is set to `true`, this is
optional and defaults to true even if the value is `{}`.

Authorization to a page is controlled by the `authz` entry in a route entry. For example
```json
"/Workspace" : {
  "loginRequired": true,
  "authz": ["/workspace"]
}
```

will only allow users with the `/workspace` role to view the `/Workspace` page.

The `*` key in the `routes` object is used to set the default authentication and authorization settings for all pages that do not
have a specific entry in the `routes` object. The is a way to set the default authentication and authorization settings for all pages.

## Navigation Links
There are two options for displaying navigation links on the left side of the page.

* Show All Links: All links will be displayed, even if the user does not have access to the page. A tooltip will be displayed indicating if login is required. Once logged in, if the user does not have authorization to view the page a tooltip will be displayed indicating that the user does not have access.
* Hide All Unavailable Links: If a user does not have access to a page, the link will not be displayed.


### Breaking Changes

This is a breaking change. Any commons that migrated to version > 0.12.0 will require syncing with the commons-frontend-app to pick up the changes. 

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
