### PR TITLE
add width to card image for Firefox add version to next

### DIFF
--- a/packages/frontend/src/features/Analysis/AnalysisCard.tsx
+++ b/packages/frontend/src/features/Analysis/AnalysisCard.tsx
@@ -29,7 +29,7 @@ const AnalysisCard: React.FC<AnalysisToolConfiguration> = ({
           <Image
             src={`${image}`}
             alt={''}
-            w={500}
+            w="auto"
             classNames={{
               root: 'rounded-tl-lg rounded-tr-lg',
             }}

--- a/packages/frontend/src/features/Analysis/AnalysisCard.tsx
+++ b/packages/frontend/src/features/Analysis/AnalysisCard.tsx
@@ -28,7 +28,8 @@ const AnalysisCard: React.FC<AnalysisToolConfiguration> = ({
         <div className="p-0 h-max-1/3 h-1/3 flex justify-center items-start relative overflow-hidden">
           <Image
             src={`${image}`}
-            alt={`${title} image`}
+            alt={''}
+            w={500}
             classNames={{
               root: 'rounded-tl-lg rounded-tr-lg',
             }}

--- a/packages/sampleCommons/next.config.js
+++ b/packages/sampleCommons/next.config.js
@@ -24,6 +24,9 @@ const withMDX = require('@next/mdx')({
 
 // Next configuration with support for rewriting API to existing common services
 const nextConfig = {
+  env: {
+    version: process.env.npm_package_version
+  },
   reactStrictMode: true,
   output: 'standalone',
   allowedDevOrigins: ['local.io', '*.local.io'],


### PR DESCRIPTION
Link to JIRA ticket if there is one: 

### New Features
- add version to next, part of eventually adding it to footer 

### Bug Fixes
- add width to card image for Firefox (layout currently broken in Firefox)
- remove confusing alt text, should be empty 
