### PR TITLE
Feat/discovery search selectable fields

### DIFF
--- a/packages/frontend/src/features/Discovery/DataLoaders/AggMetaMDSProxy/DataLoader.tsx
+++ b/packages/frontend/src/features/Discovery/DataLoaders/AggMetaMDSProxy/DataLoader.tsx
@@ -18,6 +18,7 @@ export const useAggMetaMDSProxy = ({
   pagination,
   searchTerms,
   selectedFieldsForSearchIndexing,
+  searchMode,
   discoveryConfig,
   sorting,
   guidType = 'discovery_metadata',
@@ -40,12 +41,7 @@ export const useAggMetaMDSProxy = ({
     searchTerms: searchTerms,
     sorting: sorting,
     selectedFieldsForSearchIndexing: selectedFieldsForSearchIndexing,
-    /*
-    TODO: Example param
-    selectedFieldsForSearchIndexing: [
-        'study_metadata.minimal_info.study_name',
-      ],
-     */
+    searchMode: searchMode,
     selectedTags: {},
     /*
     TODO: Example param

--- a/packages/frontend/src/features/Discovery/DataLoaders/AggMetaMDSProxy/DataLoader.tsx
+++ b/packages/frontend/src/features/Discovery/DataLoaders/AggMetaMDSProxy/DataLoader.tsx
@@ -17,7 +17,7 @@ interface ProxyData {
 export const useAggMetaMDSProxy = ({
   pagination,
   searchTerms,
-  advancedSearchTerms,
+  selectedFieldsForSearchIndexing,
   discoveryConfig,
   sorting,
   guidType = 'discovery_metadata',
@@ -39,7 +39,7 @@ export const useAggMetaMDSProxy = ({
     pagination: pagination,
     searchTerms: searchTerms,
     sorting: sorting,
-    selectedFieldsForSearchIndexing: [],
+    selectedFieldsForSearchIndexing: selectedFieldsForSearchIndexing,
     /*
     TODO: Example param
     selectedFieldsForSearchIndexing: [
@@ -80,7 +80,7 @@ export const useAggMetaMDSProxy = ({
       }
     };
     fetchData();
-  }, [searchTerms, pagination, sorting]);
+  }, [searchTerms, pagination, sorting, selectedFieldsForSearchIndexing]);
 
   let advancedSearchFilterValues = [] as any;
   const advancedSearchFilters = discoveryConfig.features?.advSearchFilters ?? {

--- a/packages/frontend/src/features/Discovery/DataLoaders/AggMetaMDSProxy/DataLoader.tsx
+++ b/packages/frontend/src/features/Discovery/DataLoaders/AggMetaMDSProxy/DataLoader.tsx
@@ -76,7 +76,13 @@ export const useAggMetaMDSProxy = ({
       }
     };
     fetchData();
-  }, [searchTerms, pagination, sorting, selectedFieldsForSearchIndexing]);
+  }, [
+    searchTerms,
+    pagination,
+    sorting,
+    selectedFieldsForSearchIndexing,
+    searchMode,
+  ]);
 
   let advancedSearchFilterValues = [] as any;
   const advancedSearchFilters = discoveryConfig.features?.advSearchFilters ?? {

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -16,6 +16,7 @@ import AiSearch from './Search/AiSearch';
 import { getDiscoveryDataLoader } from './DataLoaders/registeredDataLoaders';
 import StudyProvider from '../Study/StudyProvider';
 import { useDeepCompareMemo } from 'use-deep-compare';
+import SearchInputSelectableFields from './Search/SearchInputSelectableFields';
 
 export interface DiscoveryIndexPanelProps {
   discoveryConfig: DiscoveryIndexConfig;
@@ -136,6 +137,12 @@ const DiscoveryIndexPanel = ({
                   }
                   label={
                     discoveryConfig?.features?.search?.searchBar?.inputSubtitle
+                  }
+                />
+                <SearchInputSelectableFields
+                  searchableAndSelectableTextFields={
+                    discoveryConfig?.features?.search?.searchBar
+                      ?.searchableAndSelectableTextFields
                   }
                 />
               </div>

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -94,10 +94,6 @@ const DiscoveryIndexPanel = ({
     sorting,
     selectedFieldsForSearchIndexing: selectedFieldsForSearchIndexing,
   });
-  console.log(
-    'selectedFieldsForSearchIndexing in DiscoveryIndexPanel',
-    selectedFieldsForSearchIndexing,
-  );
   const selectedRecords = useMemo(() => {
     const uidField = discoveryConfig?.minimalFieldMapping?.uid ?? 'guid';
     const filterSelectedMembers = (data: Array<Record<string, any>>) =>
@@ -147,6 +143,10 @@ const DiscoveryIndexPanel = ({
                   }
                 />
                 <SearchInputSelectableFields
+                  searchableTextFields={
+                    discoveryConfig?.features?.search?.searchBar
+                      ?.searchableTextFields
+                  }
                   searchableAndSelectableTextFields={
                     discoveryConfig?.features?.search?.searchBar
                       ?.searchableAndSelectableTextFields

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -5,7 +5,7 @@ import DiscoveryProvider from './DiscoveryProvider';
 import { Button, Text } from '@mantine/core';
 import AdvancedSearchPanel from './Search/AdvancedSearchPanel';
 import { MRT_PaginationState, MRT_SortingState } from 'mantine-react-table';
-import { useDisclosure } from '@mantine/hooks';
+import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import ActionBar from './ActionBar/ActionBar';
 import SummaryStatisticPanel from './Statistics/SummaryStatisticPanel';
 import { CollapsableCharts } from '../../components/charts';
@@ -17,7 +17,7 @@ import { getDiscoveryDataLoader } from './DataLoaders/registeredDataLoaders';
 import StudyProvider from '../Study/StudyProvider';
 import { useDeepCompareMemo } from 'use-deep-compare';
 import SearchInputSelectableFields from './Search/SearchInputSelectableFields';
-import { SearchMode } from './constants';
+import { DEBOUNCE_DELAY_TIME, SearchMode } from './constants';
 
 export interface DiscoveryIndexPanelProps {
   discoveryConfig: DiscoveryIndexConfig;
@@ -55,6 +55,10 @@ const DiscoveryIndexPanel = ({
 
   const parentDivRef = useRef<HTMLDivElement>(null);
   const [searchBarTerms, setSearchBarTerms] = useState<string[]>([]);
+  const [debouncedSearchBarTerms] = useDebouncedValue(
+    searchBarTerms,
+    DEBOUNCE_DELAY_TIME,
+  );
   const [selections, setSelections] = useState<string[]>([]); // table selections
   const [sorting, setSorting] = useState<MRT_SortingState>([]);
   const [advancedSearchTerms, setAdvancedSearchTerms] =
@@ -67,11 +71,11 @@ const DiscoveryIndexPanel = ({
     return {
       keyword: {
         operator: SearchCombination.and,
-        keywords: searchBarTerms,
+        keywords: debouncedSearchBarTerms,
       },
       advancedSearchTerms: advancedSearchTerms,
     };
-  }, [searchBarTerms, advancedSearchTerms]);
+  }, [debouncedSearchBarTerms, advancedSearchTerms]);
 
   const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
     useState([] as string[]);

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -72,6 +72,9 @@ const DiscoveryIndexPanel = ({
     };
   }, [searchBarTerms, advancedSearchTerms]);
 
+  const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
+    useState([]);
+
   // Get all required data from the data hook. This includes the metadata, search suggestions, and results, pagination, etc.
   const {
     data,
@@ -89,8 +92,12 @@ const DiscoveryIndexPanel = ({
     searchTerms: searchParam,
     discoveryConfig,
     sorting,
+    selectedFieldsForSearchIndexing: selectedFieldsForSearchIndexing,
   });
-
+  console.log(
+    'selectedFieldsForSearchIndexing in DiscoveryIndexPanel',
+    selectedFieldsForSearchIndexing,
+  );
   const selectedRecords = useMemo(() => {
     const uidField = discoveryConfig?.minimalFieldMapping?.uid ?? 'guid';
     const filterSelectedMembers = (data: Array<Record<string, any>>) =>
@@ -143,6 +150,9 @@ const DiscoveryIndexPanel = ({
                   searchableAndSelectableTextFields={
                     discoveryConfig?.features?.search?.searchBar
                       ?.searchableAndSelectableTextFields
+                  }
+                  setSelectedFieldsForSearchIndexing={
+                    setSelectedFieldsForSearchIndexing
                   }
                 />
               </div>

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -17,6 +17,7 @@ import { getDiscoveryDataLoader } from './DataLoaders/registeredDataLoaders';
 import StudyProvider from '../Study/StudyProvider';
 import { useDeepCompareMemo } from 'use-deep-compare';
 import SearchInputSelectableFields from './Search/SearchInputSelectableFields';
+import { SearchMode } from './constants';
 
 export interface DiscoveryIndexPanelProps {
   discoveryConfig: DiscoveryIndexConfig;
@@ -74,6 +75,9 @@ const DiscoveryIndexPanel = ({
 
   const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
     useState([] as string[]);
+  const [searchMode, setSearchMode] = useState<SearchMode>(
+    SearchMode.FULL_TEXT,
+  );
 
   // Get all required data from the data hook. This includes the metadata, search suggestions, and results, pagination, etc.
   const {
@@ -93,7 +97,9 @@ const DiscoveryIndexPanel = ({
     discoveryConfig,
     sorting,
     selectedFieldsForSearchIndexing: selectedFieldsForSearchIndexing,
+    searchMode: searchMode,
   });
+
   const selectedRecords = useMemo(() => {
     const uidField = discoveryConfig?.minimalFieldMapping?.uid ?? 'guid';
     const filterSelectedMembers = (data: Array<Record<string, any>>) =>
@@ -143,6 +149,8 @@ const DiscoveryIndexPanel = ({
                   }
                 />
                 <SearchInputSelectableFields
+                  searchMode={searchMode}
+                  setSearchMode={setSearchMode}
                   searchableTextFields={
                     discoveryConfig?.features?.search?.searchBar
                       ?.searchableTextFields

--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -73,7 +73,7 @@ const DiscoveryIndexPanel = ({
   }, [searchBarTerms, advancedSearchTerms]);
 
   const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
-    useState([]);
+    useState([] as string[]);
 
   // Get all required data from the data hook. This includes the metadata, search suggestions, and results, pagination, etc.
   const {

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -5,6 +5,8 @@ import { SearchInputProps } from './types';
 import { SearchMode } from '../constants';
 
 interface SearchInputSelectableFieldsProps {
+  searchMode: SearchMode;
+  setSearchMode: React.Dispatch<React.SetStateAction<SearchMode>>;
   searchableTextFields: string[] | undefined;
   searchableAndSelectableTextFields:
     | {
@@ -17,13 +19,14 @@ interface SearchInputSelectableFieldsProps {
 }
 
 const SearchInputSelectableFields = ({
+  searchMode,
+  setSearchMode,
   searchableTextFields,
   searchableAndSelectableTextFields,
   setSelectedFieldsForSearchIndexing,
 }: SearchInputSelectableFieldsProps) => {
   if (!searchableAndSelectableTextFields || !searchableTextFields) return;
 
-  const [searchMode, setSearchMode] = useState(SearchMode.FULL_TEXT);
   const [checkboxGroupValues, setCheckboxGroupValues] = useState(
     [] as string[],
   );
@@ -43,8 +46,6 @@ const SearchInputSelectableFields = ({
 
   const onCheckboxGroupChange = (currentCheckedValues: string[]) => {
     setCheckboxGroupValues(currentCheckedValues);
-    console.log('checkboxGroupValues', checkboxGroupValues);
-    console.log('currentCheckedValues', currentCheckedValues);
     setSelectedFieldsForSearchIndexing(currentCheckedValues);
   };
 
@@ -77,7 +78,7 @@ const SearchInputSelectableFields = ({
                 disabled={searchMode === SearchMode.FULL_TEXT}
               />
             </div>
-          ))}{' '}
+          ))}
         </div>
       </Checkbox.Group>
     </>

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -6,36 +6,44 @@ import { SearchMode } from '../constants';
 
 const SearchInputSelectableFields = ({
   searchableAndSelectableTextFields,
-}: {
-  [key: string]: string | undefined;
+  setSelectedFieldsForSearchIndexing,
 }) => {
   if (!searchableAndSelectableTextFields) return;
 
   const [searchMode, setSearchMode] = useState(SearchMode.FULL_TEXT);
-  const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
-    useState({});
+  /* const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
+    useState([]); */
   const searchableTextFields: string[] = [];
   const [checkboxGroupValues, setCheckboxGroupValues] = useState([]);
 
   const onRadioChange = (value: string) => {
     setSearchMode(value as SearchMode);
     if (value === SearchMode.FULL_TEXT) {
-      setSelectedFieldsForSearchIndexing([
+      /*       setSelectedFieldsForSearchIndexing([
         ...searchableTextFields,
         ...Object.values(searchableAndSelectableTextFields),
-      ]);
-      console.log(
+      ]); */
+      setSelectedFieldsForSearchIndexing([]);
+      /*       console.log(
         'value === SearchMode.FULL_TEXT and selectedFieldsForSearchIndexing:',
         selectedFieldsForSearchIndexing,
-      );
+      ); */
     } else {
+      console.log('checkboxGroupValues', checkboxGroupValues);
       setCheckboxGroupValues(checkboxGroupValues);
       setSelectedFieldsForSearchIndexing(checkboxGroupValues);
-      console.log(
+      /*       console.log(
         'value === SearchMode.RESTRICTED and selectedFieldsForSearchIndexing:',
         selectedFieldsForSearchIndexing,
-      );
+      ); */
     }
+  };
+
+  const onCheckboxGroupChange = (currentCheckedValues) => {
+    setCheckboxGroupValues(currentCheckedValues);
+    console.log('checkboxGroupValues', checkboxGroupValues);
+    console.log('currentCheckedValues', currentCheckedValues);
+    setSelectedFieldsForSearchIndexing(currentCheckedValues);
   };
 
   const checkboxGroupOptions = Object.entries(
@@ -53,18 +61,24 @@ const SearchInputSelectableFields = ({
           />
         </div>
       </Radio.Group>
-      <div className="flex flex-wrap">
-        {checkboxGroupOptions.map((checkbox, index) => (
-          <div key={index} className="flex items-center mt-1 mr-4">
-            <Checkbox
-              key={index}
-              label={checkbox.label}
-              value={checkbox.value}
-              disabled={searchMode === SearchMode.FULL_TEXT}
-            />
-          </div>
-        ))}
-      </div>
+
+      <Checkbox.Group
+        value={checkboxGroupValues}
+        onChange={onCheckboxGroupChange}
+      >
+        <div className="flex flex-wrap">
+          {checkboxGroupOptions.map((checkbox, index) => (
+            <div key={index} className="flex items-center mt-1 mr-4">
+              <Checkbox
+                key={index}
+                label={checkbox.label}
+                value={checkbox.value as string}
+                disabled={searchMode === SearchMode.FULL_TEXT}
+              />
+            </div>
+          ))}{' '}
+        </div>
+      </Checkbox.Group>
     </>
   );
 };

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -4,42 +4,51 @@ import { Checkbox, Radio, TextInput } from '@mantine/core';
 import { SearchInputProps } from './types';
 import { SearchMode } from '../constants';
 
+interface SearchInputSelectableFieldsProps {
+  searchableAndSelectableTextFields:
+    | {
+        [key: string]: string;
+      }
+    | undefined;
+  setSelectedFieldsForSearchIndexing: React.Dispatch<
+    React.SetStateAction<string[]>
+  >;
+}
+
 const SearchInputSelectableFields = ({
   searchableAndSelectableTextFields,
   setSelectedFieldsForSearchIndexing,
-}) => {
+}: SearchInputSelectableFieldsProps) => {
   if (!searchableAndSelectableTextFields) return;
 
   const [searchMode, setSearchMode] = useState(SearchMode.FULL_TEXT);
-  /* const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
-    useState([]); */
   const searchableTextFields: string[] = [];
-  const [checkboxGroupValues, setCheckboxGroupValues] = useState([]);
+  const [checkboxGroupValues, setCheckboxGroupValues] = useState(
+    [] as string[],
+  );
 
   const onRadioChange = (value: string) => {
     setSearchMode(value as SearchMode);
     if (value === SearchMode.FULL_TEXT) {
-      /*       setSelectedFieldsForSearchIndexing([
+      setSelectedFieldsForSearchIndexing([
         ...searchableTextFields,
         ...Object.values(searchableAndSelectableTextFields),
-      ]); */
-      setSelectedFieldsForSearchIndexing([]);
-      /*       console.log(
+      ]);
+      console.log(
         'value === SearchMode.FULL_TEXT and selectedFieldsForSearchIndexing:',
-        selectedFieldsForSearchIndexing,
-      ); */
+        [
+          ...searchableTextFields,
+          ...Object.values(searchableAndSelectableTextFields),
+        ],
+      );
     } else {
       console.log('checkboxGroupValues', checkboxGroupValues);
       setCheckboxGroupValues(checkboxGroupValues);
       setSelectedFieldsForSearchIndexing(checkboxGroupValues);
-      /*       console.log(
-        'value === SearchMode.RESTRICTED and selectedFieldsForSearchIndexing:',
-        selectedFieldsForSearchIndexing,
-      ); */
     }
   };
 
-  const onCheckboxGroupChange = (currentCheckedValues) => {
+  const onCheckboxGroupChange = (currentCheckedValues: string[]) => {
     setCheckboxGroupValues(currentCheckedValues);
     console.log('checkboxGroupValues', checkboxGroupValues);
     console.log('currentCheckedValues', currentCheckedValues);

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { MdSearch as SearchIcon, MdClose as CloseIcon } from 'react-icons/md';
-import { Checkbox, Radio, TextInput } from '@mantine/core';
-import { SearchInputProps } from './types';
+import { Checkbox, Radio } from '@mantine/core';
 import { SearchMode } from '../constants';
 
 interface SearchInputSelectableFieldsProps {

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -25,12 +25,10 @@ const SearchInputSelectableFields = ({
   searchableAndSelectableTextFields,
   setSelectedFieldsForSearchIndexing,
 }: SearchInputSelectableFieldsProps) => {
-  if (!searchableAndSelectableTextFields || !searchableTextFields) return;
-
   const [checkboxGroupValues, setCheckboxGroupValues] = useState(
     [] as string[],
   );
-
+  if (!searchableAndSelectableTextFields || !searchableTextFields) return;
   const onRadioChange = (value: string) => {
     setSearchMode(value as SearchMode);
     if (value === SearchMode.FULL_TEXT) {

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { MdSearch as SearchIcon, MdClose as CloseIcon } from 'react-icons/md';
+import { Checkbox, Radio, TextInput } from '@mantine/core';
+import { SearchInputProps } from './types';
+import { SearchMode } from '../constants';
+
+const SearchInputSelectableFields = ({
+  searchableAndSelectableTextFields,
+}: {
+  [key: string]: string | undefined;
+}) => {
+  if (!searchableAndSelectableTextFields) return;
+
+  const [searchMode, setSearchMode] = useState(SearchMode.FULL_TEXT);
+  const [selectedFieldsForSearchIndexing, setSelectedFieldsForSearchIndexing] =
+    useState({});
+  const searchableTextFields: string[] = [];
+  const [checkboxGroupValues, setCheckboxGroupValues] = useState([]);
+
+  const onRadioChange = (value: string) => {
+    setSearchMode(value as SearchMode);
+    if (value === SearchMode.FULL_TEXT) {
+      setSelectedFieldsForSearchIndexing([
+        ...searchableTextFields,
+        ...Object.values(searchableAndSelectableTextFields),
+      ]);
+      console.log(
+        'value === SearchMode.FULL_TEXT and selectedFieldsForSearchIndexing:',
+        selectedFieldsForSearchIndexing,
+      );
+    } else {
+      setCheckboxGroupValues(checkboxGroupValues);
+      setSelectedFieldsForSearchIndexing(checkboxGroupValues);
+      console.log(
+        'value === SearchMode.RESTRICTED and selectedFieldsForSearchIndexing:',
+        selectedFieldsForSearchIndexing,
+      );
+    }
+  };
+
+  const checkboxGroupOptions = Object.entries(
+    searchableAndSelectableTextFields,
+  ).map(([key, value]) => ({ label: key, value }));
+
+  return (
+    <>
+      <Radio.Group onChange={onRadioChange} value={searchMode}>
+        <div className="flex space-x-4 pt-4">
+          <Radio value={SearchMode.FULL_TEXT} label="Full Text Search" />
+          <Radio
+            value={SearchMode.RESTRICTED}
+            label="Restrict Search to Selected Fields"
+          />
+        </div>
+      </Radio.Group>
+      <div className="flex flex-wrap">
+        {checkboxGroupOptions.map((checkbox, index) => (
+          <div key={index} className="flex items-center mt-1 mr-4">
+            <Checkbox
+              key={index}
+              label={checkbox.label}
+              value={checkbox.value}
+              disabled={searchMode === SearchMode.FULL_TEXT}
+            />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default SearchInputSelectableFields;

--- a/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
+++ b/packages/frontend/src/features/Discovery/Search/SearchInputSelectableFields.tsx
@@ -5,6 +5,7 @@ import { SearchInputProps } from './types';
 import { SearchMode } from '../constants';
 
 interface SearchInputSelectableFieldsProps {
+  searchableTextFields: string[] | undefined;
   searchableAndSelectableTextFields:
     | {
         [key: string]: string;
@@ -16,13 +17,13 @@ interface SearchInputSelectableFieldsProps {
 }
 
 const SearchInputSelectableFields = ({
+  searchableTextFields,
   searchableAndSelectableTextFields,
   setSelectedFieldsForSearchIndexing,
 }: SearchInputSelectableFieldsProps) => {
-  if (!searchableAndSelectableTextFields) return;
+  if (!searchableAndSelectableTextFields || !searchableTextFields) return;
 
   const [searchMode, setSearchMode] = useState(SearchMode.FULL_TEXT);
-  const searchableTextFields: string[] = [];
   const [checkboxGroupValues, setCheckboxGroupValues] = useState(
     [] as string[],
   );
@@ -34,15 +35,7 @@ const SearchInputSelectableFields = ({
         ...searchableTextFields,
         ...Object.values(searchableAndSelectableTextFields),
       ]);
-      console.log(
-        'value === SearchMode.FULL_TEXT and selectedFieldsForSearchIndexing:',
-        [
-          ...searchableTextFields,
-          ...Object.values(searchableAndSelectableTextFields),
-        ],
-      );
     } else {
-      console.log('checkboxGroupValues', checkboxGroupValues);
       setCheckboxGroupValues(checkboxGroupValues);
       setSelectedFieldsForSearchIndexing(checkboxGroupValues);
     }
@@ -70,7 +63,6 @@ const SearchInputSelectableFields = ({
           />
         </div>
       </Radio.Group>
-
       <Checkbox.Group
         value={checkboxGroupValues}
         onChange={onCheckboxGroupChange}

--- a/packages/frontend/src/features/Discovery/constants.ts
+++ b/packages/frontend/src/features/Discovery/constants.ts
@@ -4,3 +4,5 @@ export enum SearchMode {
   FULL_TEXT = 'fullTextSearch',
   RESTRICTED = 'restrictSearch',
 }
+
+export const DEBOUNCE_DELAY_TIME = 250;

--- a/packages/frontend/src/features/Discovery/constants.ts
+++ b/packages/frontend/src/features/Discovery/constants.ts
@@ -1,1 +1,6 @@
 export const METADATA_ITEM_AUTHORIZATION_FIELD = '__accessible';
+
+export enum SearchMode {
+  FULL_TEXT = 'fullTextSearch',
+  RESTRICTED = 'restrictSearch',
+}

--- a/packages/frontend/src/features/Discovery/types.ts
+++ b/packages/frontend/src/features/Discovery/types.ts
@@ -18,6 +18,7 @@ import {
 } from '../Study/types';
 import { DataAuthorization } from '../../utils';
 import { Gen3AppConfigData } from '../../lib/content/types';
+import { SearchMode } from './constants';
 
 interface KeywordSearch {
   keywords?: string[];
@@ -34,7 +35,8 @@ export interface DiscoveryDataLoaderProps extends Record<string, any> {
   pagination: MetadataPaginationParams;
   searchTerms: SearchTerms;
   discoveryConfig: DiscoveryIndexConfig;
-  selectedFieldsForSearchIndexing: string[];
+  selectedFieldsForSearchIndexing?: string[];
+  searchMode?: SearchMode;
 }
 
 export interface DataRequestStatus {

--- a/packages/frontend/src/features/Discovery/types.ts
+++ b/packages/frontend/src/features/Discovery/types.ts
@@ -148,6 +148,7 @@ export interface SearchBar {
   inputSubtitle: string;
   placeholder?: string;
   searchableTextFields: Array<string>;
+  searchableAndSelectableTextFields: { [key: string]: string };
 }
 
 interface TagSearchDropdown {

--- a/packages/frontend/src/features/Discovery/types.ts
+++ b/packages/frontend/src/features/Discovery/types.ts
@@ -34,6 +34,7 @@ export interface DiscoveryDataLoaderProps extends Record<string, any> {
   pagination: MetadataPaginationParams;
   searchTerms: SearchTerms;
   discoveryConfig: DiscoveryIndexConfig;
+  selectedFieldsForSearchIndexing: string[];
 }
 
 export interface DataRequestStatus {

--- a/packages/sampleCommons/src/pages/api/discovery/index.ts
+++ b/packages/sampleCommons/src/pages/api/discovery/index.ts
@@ -24,6 +24,7 @@ const processData = (data: Array<JSONObject>, reqBody: any) => {
     sorting,
     selectedTags,
     selectedFieldsForSearchIndexing,
+    searchMode,
     discoveryConfig,
   } = reqBody;
   let processedData: Array<JSONObject> = data;
@@ -32,6 +33,7 @@ const processData = (data: Array<JSONObject>, reqBody: any) => {
     data,
     searchTerms.keyword.keywords,
     selectedFieldsForSearchIndexing,
+    searchMode,
     discoveryConfig,
   );
   // Then Adv Search Filtering (user selected filters)

--- a/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
+++ b/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
@@ -13,7 +13,6 @@ const searchData = (
   // do not execute search if there are no search terms
   if (searchTerms.length === 0 || searchTerms.every((item) => item === ''))
     return data;
-  console.log('searchMode:', searchMode);
   let searchOverFields;
   if (
     selectedFieldsForSearchIndexing.length > 0 ||

--- a/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
+++ b/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
@@ -19,12 +19,6 @@ const searchData = (
     searchOverFields =
       discoveryConfig?.features?.search?.searchBar?.searchableTextFields || [];
   }
-  console.log(
-    'selectedFieldsForSearchIndexing',
-    selectedFieldsForSearchIndexing,
-  );
-  console.log('searchOverFields', searchOverFields);
-
   const uidField = discoveryConfig?.minimalFieldMapping?.uid || '_hdp_uid';
   // Convert Search Terms into single string
   const searchTermsSpaceSeparated = searchTerms.join(' ').trim();

--- a/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
+++ b/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
@@ -19,6 +19,11 @@ const searchData = (
     searchOverFields =
       discoveryConfig?.features?.search?.searchBar?.searchableTextFields || [];
   }
+  console.log(
+    'selectedFieldsForSearchIndexing',
+    selectedFieldsForSearchIndexing,
+  );
+  console.log('searchOverFields', searchOverFields);
 
   const uidField = discoveryConfig?.minimalFieldMapping?.uid || '_hdp_uid';
   // Convert Search Terms into single string

--- a/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
+++ b/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
@@ -1,19 +1,24 @@
 import MiniSearch from 'minisearch';
 import { JSONObject } from '@gen3/core';
 import { JSONPath } from 'jsonpath-plus';
+import { SearchMode } from '../types/discoveryApi';
 
 const searchData = (
   data: Array<JSONObject>,
   searchTerms: Array<string>,
   selectedFieldsForSearchIndexing: Array<string>,
+  searchMode: SearchMode,
   discoveryConfig: any,
 ) => {
   // do not execute search if there are no search terms
   if (searchTerms.length === 0 || searchTerms.every((item) => item === ''))
     return data;
-
+  console.log('searchMode:', searchMode);
   let searchOverFields;
-  if (selectedFieldsForSearchIndexing.length > 0) {
+  if (
+    selectedFieldsForSearchIndexing.length > 0 ||
+    searchMode === SearchMode.RESTRICTED
+  ) {
     searchOverFields = selectedFieldsForSearchIndexing;
   } else {
     searchOverFields =

--- a/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
+++ b/packages/sampleCommons/src/utils/api/discovery/processData/searchData.ts
@@ -19,6 +19,7 @@ const searchData = (
     searchOverFields =
       discoveryConfig?.features?.search?.searchBar?.searchableTextFields || [];
   }
+
   const uidField = discoveryConfig?.minimalFieldMapping?.uid || '_hdp_uid';
   // Convert Search Terms into single string
   const searchTermsSpaceSeparated = searchTerms.join(' ').trim();

--- a/packages/sampleCommons/src/utils/api/discovery/types/discoveryApi.ts
+++ b/packages/sampleCommons/src/utils/api/discovery/types/discoveryApi.ts
@@ -348,3 +348,8 @@ export interface DiscoveryIndexConfig {
 export interface DiscoveryConfig extends Gen3AppConfigData {
   metadataConfig: Array<DiscoveryIndexConfig>;
 }
+
+export enum SearchMode {
+  FULL_TEXT = 'fullTextSearch',
+  RESTRICTED = 'restrictSearch',
+}


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/HP-2367
https://ctds-planx.atlassian.net/browse/HP-2489

Implementation of Selectable Search Fields: 
![output](https://github.com/user-attachments/assets/9f471b39-ea29-4581-9ca5-bd2194bcc684)

Implementation of Search Debouncing (the 4 letter search query only results in one request to the discovery dataloader instead of 4):
![output](https://github.com/user-attachments/assets/ca605394-6b12-4743-bed9-ee9e90b3cccb)

### New Features
* Updates Discovery Page search bar to support selectable fields
* Adds debouncing to search input
