### PR TITLE
Change default tooltip of Add To Data Library external link from "Datalibrary" to "Data Library"

### DIFF
--- a/packages/frontend/src/features/Discovery/ActionBar/AddToDataLibraryComboButton.tsx
+++ b/packages/frontend/src/features/Discovery/ActionBar/AddToDataLibraryComboButton.tsx
@@ -335,7 +335,7 @@ const AddToDataLibraryComboButton = <T extends Record<any, any>>({
           </Combobox.Options>
         </Combobox.Dropdown>
       </Combobox>
-      <Tooltip label="Open Datalibrary">
+      <Tooltip label="Open Data Library">
         <ActionIcon
           size="lg"
           onClick={gotoDataLibrary}


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/MC2DP-645

### Bug Fixes
Change default tooltip of Add To Data Library external link from "Datalibrary" to "Data Library"