### PR TITLE
Update doc links to new Gen3 docs site

### DIFF
--- a/docs/Overview/Configuration.md
+++ b/docs/Overview/Configuration.md
@@ -75,11 +75,11 @@ The topbar section is defined by:
   "topBar": {
     "items": [
       {
-        "href": "https://gen3.org/resources/user/",
+        "href": "https://docs.gen3.org/gen3-resources/user-guide/",
         "name": "About"
       },
       {
-        "href": "https://gen3.org/resources/user/",
+        "href": "https://docs.gen3.org/gen3-resources/user-guide/",
         "name": "Resources"
       }
     ],

--- a/packages/sampleCommons/config/brh/discovery.json
+++ b/packages/sampleCommons/config/brh/discovery.json
@@ -78,8 +78,8 @@
             "enableDownloadManifest": true,
             "downloadManifestButtonText": "Download",
             "documentationLinks": {
-              "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-              "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+              "gen3Client": "https://docs.gen3.org/gen3-resources/tools/data-client/",
+              "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
             }
         },
         "authorization": {

--- a/packages/sampleCommons/config/datacommons/discovery.json
+++ b/packages/sampleCommons/config/datacommons/discovery.json
@@ -42,8 +42,8 @@
           "downloadZipButtonText": "Download Zip",
           "downloadManifestButtonText": "Download Manifest",
           "documentationLinks": {
-            "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-            "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+            "gen3Client": "https://docs.gen3.org/gen3-resources/tools/data-client/",
+            "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
           },
           "verifyExternalLogins": true
         },

--- a/packages/sampleCommons/config/datacommons/navigation.json
+++ b/packages/sampleCommons/config/datacommons/navigation.json
@@ -71,7 +71,7 @@
         "name": "Browse Data"
       },
       {
-        "href": "https://gen3.org/resources/user/",
+        "href": "https://docs.gen3.org/gen3-resources/user-guide/",
         "name": "Documentation"
       }
     ],

--- a/packages/sampleCommons/config/gen3/discovery.json
+++ b/packages/sampleCommons/config/gen3/discovery.json
@@ -42,8 +42,8 @@
           "downloadZipButtonText": "Download Zip",
           "downloadManifestButtonText": "Download Manifest",
           "documentationLinks": {
-            "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-            "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+            "gen3Client": "https://docs.gen3.org/gen3-resources/tools/data-client/",
+            "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
           },
           "verifyExternalLogins": true
         },

--- a/packages/sampleCommons/config/gen3/navigation.json
+++ b/packages/sampleCommons/config/gen3/navigation.json
@@ -71,7 +71,7 @@
         "name": "Browse Data"
       },
       {
-        "href": "https://gen3.org/resources/user/",
+        "href": "https://docs.gen3.org/gen3-resources/user-guide/",
         "name": "Documentation"
       }
     ],


### PR DESCRIPTION
Update assorted Gen3 docs links from old site (gen3.org/resources) to new Gen3 docs site (docs.gen3.org)

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
