### PR TITLE
Feat/discovery details permalink

### DIFF
--- a/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryIndexPanel.tsx
@@ -19,6 +19,7 @@ import { DEBOUNCE_DELAY_TIME, SearchMode } from './constants';
 import DiscoveryDropdownTagViewer from './DiscoveryDropdownTagViewer';
 import { IoIosArrowDown, IoIosArrowUp, IoIosRefresh } from 'react-icons/io';
 import { useDiscoveryContext } from './DiscoveryProvider';
+import { useStudyIdFromWindow } from './utils/useStudyIdFromWindow';
 
 export interface DiscoveryIndexPanelProps {
   indexSelector: ReactNode | null;
@@ -57,7 +58,10 @@ const DiscoveryIndexPanel = ({ indexSelector }: DiscoveryIndexPanelProps) => {
   });
 
   const parentDivRef = useRef<HTMLDivElement>(null);
-  const [searchBarTerms, setSearchBarTerms] = useState<string[]>([]);
+  const studyIdFromWindow = useStudyIdFromWindow();
+  const [searchBarTerms, setSearchBarTerms] = useState<string[]>(
+    studyIdFromWindow ? [studyIdFromWindow] : [],
+  );
   const [debouncedSearchBarTerms] = useDebouncedValue(
     searchBarTerms,
     DEBOUNCE_DELAY_TIME,
@@ -296,6 +300,7 @@ const DiscoveryIndexPanel = ({ indexSelector }: DiscoveryIndexPanelProps) => {
               <DiscoveryTable
                 data={data}
                 hits={hits}
+                studyIdFromWindow={studyIdFromWindow as string}
                 dataRequestStatus={dataRequestStatus}
                 setPagination={setPagination}
                 setSorting={setSorting}

--- a/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { SetStateAction, useEffect, useRef, useState } from 'react';
 import {
   MantineReactTable,
   MRT_Cell,
@@ -60,6 +60,7 @@ const isSelectable = (
 interface DiscoveryTableProps {
   data: Array<Record<string, any>>;
   hits: number;
+  studyIdFromWindow?: string;
   dataRequestStatus: DataRequestStatus;
   pagination: MRT_PaginationState;
   sorting: MRT_SortingState;
@@ -73,6 +74,7 @@ interface DiscoveryTableProps {
 const DiscoveryTable = ({
   data,
   hits,
+  studyIdFromWindow,
   dataRequestStatus,
   setSorting,
   setPagination,
@@ -88,6 +90,19 @@ const DiscoveryTable = ({
   const { isLoading, isError, isFetching } = dataRequestStatus;
   const manualSortingAndPagination = getManualSortingAndPagination(config);
   const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({}); //ts type available
+
+  useEffect(() => {
+    if (!studyIdFromWindow || !data) return;
+    const uidKey = config.minimalFieldMapping.uid;
+
+    if (Array.isArray(data)) {
+      const foundStudy = data.find(
+        (item) => item[uidKey] === studyIdFromWindow,
+      );
+
+      foundStudy && setStudyDetails(foundStudy);
+    }
+  }, [studyIdFromWindow, data]);
 
   const extractCellValue =
     (func: CellRendererFunction) =>
@@ -219,6 +234,7 @@ const DiscoveryTable = ({
     mantineTableBodyRowProps: ({ row }) => ({
       onClick: () => {
         setStudyDetails(() => {
+          console.log('row.original', row.original);
           return { ...row.original };
         });
       },

--- a/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
@@ -94,7 +94,6 @@ const DiscoveryTable = ({
   useEffect(() => {
     if (!studyIdFromWindow || !data) return;
     const uidKey = config.minimalFieldMapping.uid;
-
     if (Array.isArray(data)) {
       const foundStudy = data.find(
         (item) => item[uidKey] === studyIdFromWindow,

--- a/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
@@ -98,7 +98,7 @@ const DiscoveryTable = ({
       const foundStudy = data.find(
         (item) => item[uidKey] === studyIdFromWindow,
       );
-      foundStudy && setStudyDetails(foundStudy);
+      if (foundStudy) setStudyDetails(foundStudy);
     }
   }, [studyIdFromWindow, data]);
 

--- a/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
+++ b/packages/frontend/src/features/Discovery/DiscoveryTable/DiscoveryTable.tsx
@@ -99,7 +99,6 @@ const DiscoveryTable = ({
       const foundStudy = data.find(
         (item) => item[uidKey] === studyIdFromWindow,
       );
-
       foundStudy && setStudyDetails(foundStudy);
     }
   }, [studyIdFromWindow, data]);
@@ -234,7 +233,6 @@ const DiscoveryTable = ({
     mantineTableBodyRowProps: ({ row }) => ({
       onClick: () => {
         setStudyDetails(() => {
-          console.log('row.original', row.original);
           return { ...row.original };
         });
       },

--- a/packages/frontend/src/features/Discovery/utils/useStudyIdFromWindow.ts
+++ b/packages/frontend/src/features/Discovery/utils/useStudyIdFromWindow.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+
+const getStudyIdFromPath = (pathname?: string): string | null => {
+  if (!pathname) return null;
+  const match = pathname.match(new RegExp('^/Discovery/([^/?#]+)', 'i'));
+  return match ? match[1] : null;
+};
+
+export const useStudyIdFromWindow = (): string | null => {
+  return useMemo(() => {
+    if (typeof window === 'undefined') return null;
+    return getStudyIdFromPath(window.location.pathname);
+  }, []);
+};

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
@@ -19,7 +19,7 @@ const StudyDetails = ({
   simpleDetailsView?: StudyPageConfig;
   authz: DataAuthorization;
 }) => {
-  const { studyDetails } = useStudyContext();
+  const { studyDetails, setStudyDetails } = useStudyContext();
   const [opened, { open, close }] = useDisclosure(false);
   if (!studyDetails) {
     return null;
@@ -27,6 +27,7 @@ const StudyDetails = ({
 
   const defaultPermaLinkValue = 'Discovery/notfound';
   const [permalink, setPermalink] = useState(defaultPermaLinkValue);
+  const hasStudyDetails = Object.keys(studyDetails).length > 0;
 
   useEffect(() => {
     const studyId = toString(studyDetails[index]);
@@ -43,45 +44,42 @@ const StudyDetails = ({
     }
     if (opened === false) {
       // if drawer has been shut, reset study details
-      // setStudyDetails({});
+      setStudyDetails({});
     }
   }, [opened]);
 
   useEffect(() => {
-    if (Object.keys(studyDetails).length > 0) {
+    if (hasStudyDetails) {
       open();
     }
   }, [studyDetails, open]);
 
   return (
     <Drawer.Root opened={opened} onClose={close} size="50%" position="right">
-      <Drawer.Overlay opacity={0.5} blur={4} />
-      <Drawer.Content className="pl-2">
-        <Drawer.Header>
-          <StudyDetailsHeaderButtons
-            studyIndex={index}
-            onClose={close}
-            opened={opened}
-            permalink={permalink}
-          />
-        </Drawer.Header>
-        <Drawer.Body>
-          {detailView ? (
-            <StudyDetailsPanel
-              data={studyDetails ?? {}}
-              studyConfig={detailView}
-            />
-          ) : simpleDetailsView ? (
-            <SinglePageStudyDetailsPanel
-              data={studyDetails ?? {}}
-              studyConfig={simpleDetailsView}
-              authorization={authz}
-            />
-          ) : (
-            <div>Study Details Panel not configured</div>
-          )}
-        </Drawer.Body>
-      </Drawer.Content>
+      <Drawer.Overlay opacity={0.5} blur={4} />{' '}
+      {hasStudyDetails && (
+        <Drawer.Content className="pl-2">
+          <Drawer.Header>
+            <StudyDetailsHeaderButtons onClose={close} permalink={permalink} />
+          </Drawer.Header>
+          <Drawer.Body>
+            {detailView ? (
+              <StudyDetailsPanel
+                data={studyDetails ?? {}}
+                studyConfig={detailView}
+              />
+            ) : simpleDetailsView ? (
+              <SinglePageStudyDetailsPanel
+                data={studyDetails ?? {}}
+                studyConfig={simpleDetailsView}
+                authorization={authz}
+              />
+            ) : (
+              <div>Study Details Panel not configured</div>
+            )}
+          </Drawer.Body>
+        </Drawer.Content>
+      )}
     </Drawer.Root>
   );
 };

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
@@ -22,7 +22,6 @@ const StudyDetails = ({
 }) => {
   const { studyDetails, setStudyDetails } = useStudyContext();
   const [opened, { open, close }] = useDisclosure(false);
-
   const defaultPermaLinkValue = 'Discovery/notfound';
   const [permalink, setPermalink] = useState(defaultPermaLinkValue);
   const hasStudyDetails = Object.keys(studyDetails).length > 0;

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
@@ -8,6 +8,7 @@ import { StudyDetailView, StudyPageConfig } from '../types';
 import { DataAuthorization } from '../../../utils';
 import StudyDetailsHeaderButtons from './StudyDetailsHeaderButtons';
 import { toString } from 'lodash';
+
 const StudyDetails = ({
   index,
   detailView,
@@ -21,9 +22,6 @@ const StudyDetails = ({
 }) => {
   const { studyDetails, setStudyDetails } = useStudyContext();
   const [opened, { open, close }] = useDisclosure(false);
-  if (!studyDetails) {
-    return null;
-  }
 
   const defaultPermaLinkValue = 'Discovery/notfound';
   const [permalink, setPermalink] = useState(defaultPermaLinkValue);

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
@@ -8,7 +8,6 @@ import { StudyDetailView, StudyPageConfig } from '../types';
 import { DataAuthorization } from '../../../utils';
 import StudyDetailsHeaderButtons from './StudyDetailsHeaderButtons';
 import { toString } from 'lodash';
-
 const StudyDetails = ({
   index,
   detailView,
@@ -20,18 +19,12 @@ const StudyDetails = ({
   simpleDetailsView?: StudyPageConfig;
   authz: DataAuthorization;
 }) => {
-  const { studyDetails, setStudyDetails } = useStudyContext();
+  const { studyDetails } = useStudyContext();
   const [opened, { open, close }] = useDisclosure(false);
-
-  useEffect(() => {
-    if (Object.keys(studyDetails).length > 0) {
-      open();
-    }
-  }, [studyDetails, open]);
-
   if (!studyDetails) {
     return null;
   }
+
   const defaultPermaLinkValue = 'Discovery/notfound';
   const [permalink, setPermalink] = useState(defaultPermaLinkValue);
 
@@ -50,16 +43,27 @@ const StudyDetails = ({
     }
     if (opened === false) {
       // if drawer has been shut, reset study details
-      setStudyDetails({});
+      // setStudyDetails({});
     }
   }, [opened]);
+
+  useEffect(() => {
+    if (Object.keys(studyDetails).length > 0) {
+      open();
+    }
+  }, [studyDetails, open]);
 
   return (
     <Drawer.Root opened={opened} onClose={close} size="50%" position="right">
       <Drawer.Overlay opacity={0.5} blur={4} />
       <Drawer.Content className="pl-2">
         <Drawer.Header>
-          <StudyDetailsHeaderButtons onClose={close} permalink={permalink} />
+          <StudyDetailsHeaderButtons
+            studyIndex={index}
+            onClose={close}
+            opened={opened}
+            permalink={permalink}
+          />
         </Drawer.Header>
         <Drawer.Body>
           {detailView ? (

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Drawer } from '@mantine/core';
 import StudyDetailsPanel from './StudyDetailsPanel';
 import { useDisclosure } from '@mantine/hooks';
@@ -7,6 +7,7 @@ import { useStudyContext } from '../StudyProvider';
 import { StudyDetailView, StudyPageConfig } from '../types';
 import { DataAuthorization } from '../../../utils';
 import StudyDetailsHeaderButtons from './StudyDetailsHeaderButtons';
+import { toString } from 'lodash';
 
 const StudyDetails = ({
   index,
@@ -19,8 +20,9 @@ const StudyDetails = ({
   simpleDetailsView?: StudyPageConfig;
   authz: DataAuthorization;
 }) => {
-  const { studyDetails } = useStudyContext();
+  const { studyDetails, setStudyDetails } = useStudyContext();
   const [opened, { open, close }] = useDisclosure(false);
+
   useEffect(() => {
     if (Object.keys(studyDetails).length > 0) {
       open();
@@ -30,13 +32,34 @@ const StudyDetails = ({
   if (!studyDetails) {
     return null;
   }
+  const defaultPermaLinkValue = 'Discovery/notfound';
+  const [permalink, setPermalink] = useState(defaultPermaLinkValue);
+
+  useEffect(() => {
+    const studyId = toString(studyDetails[index]);
+    const pushUrl = (path: string) =>
+      typeof window !== 'undefined' && window.history.pushState(null, '', path);
+    if (studyId) {
+      if (opened) {
+        pushUrl(`/Discovery/${encodeURI(studyId)}`);
+        setPermalink(window?.location?.href ?? defaultPermaLinkValue);
+      } else {
+        pushUrl('/Discovery');
+        setPermalink(defaultPermaLinkValue);
+      }
+    }
+    if (opened === false) {
+      // if drawer has been shut, reset study details
+      setStudyDetails({});
+    }
+  }, [opened]);
 
   return (
     <Drawer.Root opened={opened} onClose={close} size="50%" position="right">
       <Drawer.Overlay opacity={0.5} blur={4} />
       <Drawer.Content className="pl-2">
         <Drawer.Header>
-          <StudyDetailsHeaderButtons studyIndex={index} onClose={close} />
+          <StudyDetailsHeaderButtons onClose={close} permalink={permalink} />
         </Drawer.Header>
         <Drawer.Body>
           {detailView ? (

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
@@ -17,9 +17,6 @@ const StudyDetailsHeaderButtons: React.FC<StudyDetailsHeaderButtonsProps> = ({
   //opened,
   permalink,
 }) => {
-  // Note: This doesn't seem to work, will be addressed in HP-2384
-  const { studyDetails, setStudyDetails } = useStudyContext();
-
   const requiresLogin = !useIsUserLoggedIn();
 
   return (

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
@@ -1,20 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Button, CopyButton } from '@mantine/core';
 import { MdKeyboardDoubleArrowLeft as BackIcon } from 'react-icons/md';
-import { useStudyContext } from '../StudyProvider';
 import { FiLogIn as LoginIcon } from 'react-icons/fi';
 import { useIsUserLoggedIn } from '@gen3/core';
 
 interface StudyDetailsHeaderButtonsProps {
-  //studyIndex: string;
   onClose: () => void;
-  // opened: boolean;
   permalink: string;
 }
 const StudyDetailsHeaderButtons: React.FC<StudyDetailsHeaderButtonsProps> = ({
-  //studyIndex,
   onClose,
-  //opened,
   permalink,
 }) => {
   const requiresLogin = !useIsUserLoggedIn();

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
@@ -1,28 +1,16 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, CopyButton } from '@mantine/core';
-import { MdKeyboardDoubleArrowLeft as BackIcon } from 'react-icons/md';
-import { useStudyContext } from '../StudyProvider';
+import { MdKeyboardArrowLeft as BackIcon } from 'react-icons/md';
 import { FiLogIn as LoginIcon } from 'react-icons/fi';
 import { useIsUserLoggedIn } from '@gen3/core';
-
 interface StudyDetailsHeaderButtonsProps {
-  studyIndex: string;
   onClose: () => void;
+  permalink: string;
 }
 const StudyDetailsHeaderButtons: React.FC<StudyDetailsHeaderButtonsProps> = ({
-  studyIndex,
   onClose,
+  permalink,
 }) => {
-  // Note: This doesn't seem to work, will be addressed in HP-2384
-  let permalink = 'Discovery/notfound';
-  const { studyDetails } = useStudyContext();
-  if (studyDetails) {
-    const studyId = studyDetails[studyIndex];
-    const pagePath = `/discovery/${encodeURIComponent(
-      typeof studyId == 'string' ? 'string' : 'unknown',
-    )}`;
-    permalink = `/${pagePath}`;
-  }
   const requiresLogin = !useIsUserLoggedIn();
   return (
     <>

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
@@ -13,7 +13,6 @@ const StudyDetailsHeaderButtons: React.FC<StudyDetailsHeaderButtonsProps> = ({
   permalink,
 }) => {
   const requiresLogin = !useIsUserLoggedIn();
-
   return (
     <>
       <Button leftSection={<BackIcon />} onClick={onClose} variant="outline">

--- a/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
+++ b/packages/frontend/src/features/Study/StudyDetails/StudyDetailsHeaderButtons.tsx
@@ -1,17 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import { Button, CopyButton } from '@mantine/core';
-import { MdKeyboardArrowLeft as BackIcon } from 'react-icons/md';
+import { MdKeyboardDoubleArrowLeft as BackIcon } from 'react-icons/md';
+import { useStudyContext } from '../StudyProvider';
 import { FiLogIn as LoginIcon } from 'react-icons/fi';
 import { useIsUserLoggedIn } from '@gen3/core';
+
 interface StudyDetailsHeaderButtonsProps {
+  //studyIndex: string;
   onClose: () => void;
+  // opened: boolean;
   permalink: string;
 }
 const StudyDetailsHeaderButtons: React.FC<StudyDetailsHeaderButtonsProps> = ({
+  //studyIndex,
   onClose,
+  //opened,
   permalink,
 }) => {
+  // Note: This doesn't seem to work, will be addressed in HP-2384
+  const { studyDetails, setStudyDetails } = useStudyContext();
+
   const requiresLogin = !useIsUserLoggedIn();
+
   return (
     <>
       <Button leftSection={<BackIcon />} onClick={onClose} variant="outline">

--- a/packages/frontend/src/features/Study/StudyProvider.tsx
+++ b/packages/frontend/src/features/Study/StudyProvider.tsx
@@ -14,20 +14,14 @@ const StudyContext = createContext<StudyProviderValue>({
 const useStudyContext = () => {
   const context = React.useContext(StudyContext);
   if (context === undefined) {
-    throw Error(
-      'Study must be used must be used inside of a StudyContext',
-    );
+    throw Error('Study must be used must be used inside of a StudyContext');
   }
   return context;
 };
 
-const StudyProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
+const StudyProvider = ({ children }: { children: React.ReactNode }) => {
   const [studyDetails, setStudyDetails] = React.useState<JSONObject>({});
-
+  console.log('studyDetails', studyDetails);
   return (
     <StudyContext.Provider
       value={{

--- a/packages/frontend/src/features/Study/StudyProvider.tsx
+++ b/packages/frontend/src/features/Study/StudyProvider.tsx
@@ -14,14 +14,20 @@ const StudyContext = createContext<StudyProviderValue>({
 const useStudyContext = () => {
   const context = React.useContext(StudyContext);
   if (context === undefined) {
-    throw Error('Study must be used must be used inside of a StudyContext');
+    throw Error(
+      'Study must be used must be used inside of a StudyContext',
+    );
   }
   return context;
 };
 
-const StudyProvider = ({ children }: { children: React.ReactNode }) => {
+const StudyProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const [studyDetails, setStudyDetails] = React.useState<JSONObject>({});
-  console.log('studyDetails', studyDetails);
+
   return (
     <StudyContext.Provider
       value={{

--- a/packages/sampleCommons/src/pages/Discovery/[studyId].tsx
+++ b/packages/sampleCommons/src/pages/Discovery/[studyId].tsx
@@ -1,0 +1,8 @@
+import DiscoveryPage from '@gen3/frontend/pages/Discovery/DiscoveryPage';
+import { DiscoveryPageGetServerSideProps as getServerSideProps } from '@gen3/frontend/pages/Discovery/data';
+import { registerDiscoveryCustomCellRenderers } from '@/lib/Discovery/CustomCellRenderers';
+
+registerDiscoveryCustomCellRenderers();
+
+export default DiscoveryPage;
+export { getServerSideProps };


### PR DESCRIPTION
Link to JIRA ticket if there is one:
https://ctds-planx.atlassian.net/browse/HP-2384

**Implementation**
<img width="1080" height="548" alt="output" src="https://github.com/user-attachments/assets/cffbe3e0-9084-4e8e-8a10-83cc104e46e3" />
Notes: 
* If the URL contains a study ID, then at page load this is set as a search term for the initial data query. If the response contains this study, it is set as a studyDetail and displayed in the studyDetails drawer. 
* The bug associated with the study details drawer redisplaying after being closed with a previous study was due to the studyDetails not being reset to empty once the study details drawer was closed. 

### New Features
* Adds working permalink button 
### Breaking Changes

### Bug Fixes
* Fixes bug with discovery details drawer opening unexpectedly after closing
