### PR TITLE
(GFF-569): modal overlay is higher than the z-index for the dropdown

### DIFF
--- a/packages/frontend/src/features/DataLibrary/modals/SelectedItemsModal.tsx
+++ b/packages/frontend/src/features/DataLibrary/modals/SelectedItemsModal.tsx
@@ -178,7 +178,6 @@ const SelectedItemsModal: React.FC<SelectedItemsModelProps> = (props) => {
       {...props}
       closeOnEscape
       centered
-      withinPortal={false}
       title={<ModalHeader />}
       classNames={{
         header: 'm-0 p-2 min-h-10 bg-secondary',
@@ -198,6 +197,7 @@ const SelectedItemsModal: React.FC<SelectedItemsModelProps> = (props) => {
             <Select
               data={destinations}
               value={value ? value.value : null}
+              comboboxProps={{ zIndex: 500 }}
               onChange={(value, option) => {
                 setValue(option);
                 if (value) setSelectionAction(value);

--- a/packages/frontend/src/features/DataLibrary/modals/SelectedItemsModal.tsx
+++ b/packages/frontend/src/features/DataLibrary/modals/SelectedItemsModal.tsx
@@ -195,7 +195,6 @@ const SelectedItemsModal: React.FC<SelectedItemsModelProps> = (props) => {
           <Group>
             <Text fw={600}>Destination:</Text>
             <Select
-              comboboxProps={{ zIndex: 1200 }}
               data={destinations}
               value={value ? value.value : null}
               comboboxProps={{ zIndex: 500 }}

--- a/packages/frontend/src/features/DataLibrary/tables/SelectedItemsTable.tsx
+++ b/packages/frontend/src/features/DataLibrary/tables/SelectedItemsTable.tsx
@@ -220,7 +220,7 @@ const SelectedItemsTable: React.FC<SelectedItemsTableProps> = ({
       hasInvalidRows,
     };
   }, [validatedItems]);
-
+  //TODO: get table to work better in modal
   const table = useMantineReactTable<SelectedItemsTableRow>({
     columns,
     data: tableRows.rows,
@@ -235,6 +235,7 @@ const SelectedItemsTable: React.FC<SelectedItemsTableProps> = ({
     enableStickyHeader: true,
     enableStickyFooter: true,
     enableHiding: true,
+    enableColumnActions: false,
     onRowSelectionChange: handleRowSelectionChange,
     state: { rowSelection },
     initialState: {


### PR DESCRIPTION
Link to JIRA ticket if there is one: [GFF-569](https://ctds-planx.atlassian.net/browse/GFF-569)

### Bug Fixes
- Data Library: SelectionModal's z-index for the modal overlay is higher than the z-index for the dropdown

[GFF-569]: https://ctds-planx.atlassian.net/browse/GFF-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ