### PR TITLE
Make enum facet default sorting configurable

### DIFF
--- a/docs/Configuration/Explorer.md
+++ b/docs/Configuration/Explorer.md
@@ -372,14 +372,22 @@ is also searchable.
 ### Default Facet Sorting
 
 Enum facets are sorted by value count descending by default. To use a different initial sort order for an individual
-facet, set `defaultSort` in that field's `fieldsConfig` entry:
+facet, set `defaultSort` in that field's `fieldsConfig` entry within the relevant `filters.tabs` entry:
 
 ```json
 {
-  "fieldsConfig": {
-    "gender": {
-      "defaultSort": "label-asc"
-    }
+  "filters": {
+    "tabs": [
+      {
+        "title": "Subjects",
+        "fields": ["gender"],
+        "fieldsConfig": {
+          "gender": {
+            "defaultSort": "label-asc"
+          }
+        }
+      }
+    ]
   }
 }
 ```

--- a/docs/Configuration/Explorer.md
+++ b/docs/Configuration/Explorer.md
@@ -369,6 +369,30 @@ add a ```fieldsConfig``` entry. The format is _field_ name then _type_. In the e
 switch to use ```multiselect```. Note that ```multiselect``` is the only type supported. The selection is a dropdown that
 is also searchable.
 
+### Default Facet Sorting
+
+Enum facets are sorted by value count descending by default. To use a different initial sort order for an individual
+facet, set `defaultSort` in that field's `fieldsConfig` entry:
+
+```json
+{
+  "fieldsConfig": {
+    "gender": {
+      "defaultSort": "label-asc"
+    }
+  }
+}
+```
+
+The supported values are:
+
+* `value-asc` - value count ascending
+* `value-dsc` - value count descending
+* `label-asc` - label ascending
+* `label-desc` - label descending
+
+Facets without `defaultSort` continue to use `value-dsc`.
+
 ![MultiSelectFacet](images/Explorer/MultiSelectFacet.png)
 
 ### Export Cohort Datafiles to Data Library

--- a/packages/core/src/features/facets/types.ts
+++ b/packages/core/src/features/facets/types.ts
@@ -16,6 +16,10 @@ export type FacetType =
   | 'multiselect'
   | 'upload';
 
+// compact string representation of the enum facet sort order for config files
+export type FacetSortType =
+  'value-asc' | 'value-dsc' | 'label-asc' | 'label-desc';
+
 export interface AllowableRange {
   readonly minimum: number;
   readonly maximum: number;
@@ -34,4 +38,5 @@ export interface FacetDefinition {
   readonly sharedWithIndices?: Array<IndexAndField>; // if this filter is denormalized across indices
   readonly moveValuesToBottom?: Array<string>;
   readonly excludeValues?: Array<string>;
+  readonly defaultSort?: FacetSortType;
 }

--- a/packages/frontend/src/components/facets/EnumFacet.tsx
+++ b/packages/frontend/src/components/facets/EnumFacet.tsx
@@ -23,6 +23,7 @@ const EnumFacet = ({
   sharedWithIndices = undefined,
   moveValuesToBottom = [],
   excludeValues = [],
+  defaultSort = 'value-dsc',
   header = {
     Panel: FacetHeader,
     Label: FacetText,
@@ -85,6 +86,7 @@ const EnumFacet = ({
           isSearching={isSearching}
           hideIfEmpty={hideIfEmpty}
           showPercent={showPercent}
+          sort={defaultSort}
           moveValuesToBottom={moveValuesToBottom}
           excludeValues={excludeValues}
         />

--- a/packages/frontend/src/components/facets/createFacetCard.tsx
+++ b/packages/frontend/src/components/facets/createFacetCard.tsx
@@ -66,6 +66,7 @@ export const createFacetCard = ({
               hooks={dataFunctions as EnumFacetDataHooks}
               showPercent={showPercent}
               sharedWithIndices={facetDefinition?.sharedWithIndices}
+              defaultSort={facetDefinition?.defaultSort}
               moveValuesToBottom={facetDefinition?.moveValuesToBottom ?? []}
               excludeValues={facetDefinition?.excludeValues ?? []}
             />

--- a/packages/frontend/src/components/facets/types.ts
+++ b/packages/frontend/src/components/facets/types.ts
@@ -3,6 +3,7 @@ import {
   DataFetchingResult,
   EnumFilterValue,
   FacetDefinition,
+  FacetSortType as CoreFacetSortType,
   IndexAndField,
   NumericFromTo,
   Operation,
@@ -47,6 +48,7 @@ export interface FacetCardProps<T extends FacetCommonHooks> {
   readonly queryOptions?: QueryOptions;
   readonly moveValuesToBottom?: Array<string>;
   readonly excludeValues?: Array<string>;
+  readonly defaultSort?: FacetSortType;
 
   readonly header?: {
     readonly Panel: ComponentType<{ children: ReactNode }>; // optional header component
@@ -240,12 +242,7 @@ export type NumericFacetCardProps = FacetCardProps<NumericRangeFacetHooks> & {
   readonly clearValues?: boolean;
 };
 
-// compact string representation of SortType for config file
-export type FacetSortType =
-  | 'value-asc'
-  | 'value-dsc'
-  | 'label-asc'
-  | 'label-desc';
+export type FacetSortType = CoreFacetSortType;
 
 /**
  * Sort type for enum buckets

--- a/packages/frontend/src/components/facets/utils.ts
+++ b/packages/frontend/src/components/facets/utils.ts
@@ -209,6 +209,7 @@ export const classifyFacets = (
             undefined,
           moveValuesToBottom: facetDef?.moveValuesToBottom,
           excludeValues: facetDef?.excludeValues,
+          defaultSort: facetDef?.defaultSort,
           range: facetDef?.range
             ? {
                 minimum:
@@ -458,21 +459,21 @@ export const mapFacetSortToSortType = (facetSort: FacetSortType): SortType => {
     return defaultSort;
   }
 
-  const parts = facetSort.split('-');
-
-  // Check if we have exactly 2 parts
-  if (parts.length !== 2) {
-    console.warn(
-      `Invalid facetSort format: expected 'type-direction', got '${facetSort}'. Using default.`,
-    );
-    return defaultSort;
+  switch (facetSort) {
+    case 'value-asc':
+      return { type: 'value', direction: 'asc' };
+    case 'value-dsc':
+      return { type: 'value', direction: 'dsc' };
+    case 'label-asc':
+      return { type: 'alpha', direction: 'asc' };
+    case 'label-desc':
+      return { type: 'alpha', direction: 'dsc' };
+    default:
+      console.warn(
+        `Invalid facetSort value: got '${facetSort}'. Using default.`,
+      );
+      return defaultSort;
   }
-
-  const [type, direction] = facetSort.split('-');
-  return {
-    type: type === 'label' ? 'alpha' : 'value',
-    direction: direction as 'asc' | 'dsc',
-  };
 };
 
 export const compareKeysAscending = (

--- a/packages/frontend/src/components/facets/utils.unit.test.ts
+++ b/packages/frontend/src/components/facets/utils.unit.test.ts
@@ -1,0 +1,56 @@
+import type { FacetDefinition, HistogramDataArray } from '@gen3/core';
+import { classifyFacets, mapFacetSortToSortType } from './utils';
+import type { FacetSortType } from './types';
+
+jest.mock('@gen3/core', () => ({
+  fieldNameToLabel: (field: string) => field,
+}));
+
+describe('mapFacetSortToSortType', () => {
+  test.each([
+    ['value-asc', { type: 'value', direction: 'asc' }],
+    ['value-dsc', { type: 'value', direction: 'dsc' }],
+    ['label-asc', { type: 'alpha', direction: 'asc' }],
+    ['label-desc', { type: 'alpha', direction: 'dsc' }],
+  ] as Array<[FacetSortType, ReturnType<typeof mapFacetSortToSortType>]>)(
+    'maps %s to the enum list sort state',
+    (configuredSort, expectedSort) => {
+      expect(mapFacetSortToSortType(configuredSort)).toEqual(expectedSort);
+    },
+  );
+
+  it('uses the existing value-descending default for an invalid value', () => {
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+
+    expect(mapFacetSortToSortType('invalid' as FacetSortType)).toStrictEqual({
+      type: 'value',
+      direction: 'dsc',
+    });
+    expect(consoleWarn).toHaveBeenCalled();
+
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('classifyFacets', () => {
+  it('preserves the configured default sort on the facet definition', () => {
+    const data = {
+      status: [
+        { key: 'True', count: 2 },
+        { key: 'False', count: 3 },
+      ],
+    } as Record<string, HistogramDataArray>;
+    const config = {
+      status: {
+        field: 'status',
+        index: 'case',
+        type: 'enum',
+        defaultSort: 'label-asc',
+      },
+    } satisfies Record<string, FacetDefinition>;
+
+    const facets = classifyFacets(data, 'case', [], config);
+
+    expect(facets.status.defaultSort).toBe('label-asc');
+  });
+});


### PR DESCRIPTION
* **New Features**
  * Added **Default Facet Sorting** configuration for selection facets.
  * Enum facets now honor a configured `defaultSort` and otherwise default to **value count (descending)**.
  * Supported `defaultSort` options: `value-asc`, `value-dsc`, `label-asc`, `label-desc`.
  * Improved sort parsing/validation to use explicit mappings and apply a safe fallback for invalid inputs.
* **Documentation**
  * Documented how to override initial facet ordering via `defaultSort`, including defaults and supported values.
* **Tests**
  * Added unit tests covering valid mappings, invalid-input fallback with warning, and preservation of configured `defaultSort`.